### PR TITLE
Update to Bevy 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,16 +8,18 @@ license = "MIT OR Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.9", default_features = false }
-bevy_polyline = { version = "0.4", optional = true }
+bevy = { version = "0.10", default_features = false }
+bevy_polyline = { version = "0.6", optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.9", default_features = false, features = [
+bevy = { version = "0.10", default_features = false, features = [
+    "bevy_text",
+    "bevy_ui",
     "bevy_render",
     "bevy_winit",
     "x11",
 ] }
-bevy_framepace = "0.11"
+bevy_framepace = "0.12"
 
 [features]
 default = ["debug"]

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -2,6 +2,7 @@ use bevy::{
     math::Vec3A,
     prelude::*,
     render::primitives::{Aabb, Sphere},
+    window::{CursorGrabMode, PrimaryWindow, Window, WindowMode},
 };
 use big_space::{
     camera::{CameraController, CameraInput},
@@ -97,7 +98,7 @@ fn ui_setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 color: Color::WHITE,
             },
         )
-        .with_text_alignment(TextAlignment::TOP_LEFT)
+        .with_text_alignment(TextAlignment::Left)
         .with_style(Style {
             position_type: PositionType::Absolute,
             position: UiRect {
@@ -159,25 +160,26 @@ fn ui_text_system(
 }
 
 fn cursor_grab_system(
-    mut windows: ResMut<Windows>,
+    mut windows: Query<&mut Window, With<PrimaryWindow>>,
     mut cam: ResMut<CameraInput>,
     btn: Res<Input<MouseButton>>,
     key: Res<Input<KeyCode>>,
 ) {
-    use bevy::window::CursorGrabMode;
-    let window = windows.get_primary_mut().unwrap();
+    let Some(mut window) = windows.get_single_mut().ok() else {
+        return;
+    };
 
     if btn.just_pressed(MouseButton::Left) {
-        window.set_cursor_grab_mode(CursorGrabMode::Locked);
-        window.set_cursor_visibility(false);
-        window.set_mode(WindowMode::BorderlessFullscreen);
+        window.cursor.grab_mode = CursorGrabMode::Locked;
+        window.cursor.visible = false;
+        window.mode = WindowMode::BorderlessFullscreen;
         cam.defaults_disabled = false;
     }
 
     if key.just_pressed(KeyCode::Escape) {
-        window.set_cursor_grab_mode(CursorGrabMode::None);
-        window.set_cursor_visibility(true);
-        window.set_mode(WindowMode::Windowed);
+        window.cursor.grab_mode = CursorGrabMode::None;
+        window.cursor.visible = true;
+        window.mode = WindowMode::Windowed;
         cam.defaults_disabled = true;
     }
 }

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -17,18 +17,16 @@ use crate::{precision::GridPrecision, FloatingOriginSettings, GridCell};
 pub struct CameraControllerPlugin<P: GridPrecision>(PhantomData<P>);
 impl<P: GridPrecision> Plugin for CameraControllerPlugin<P> {
     fn build(&self, app: &mut App) {
-        app.init_resource::<CameraInput>()
-            //CoreStage::PostUpdate,
-            .add_systems(
-                (
-                    default_camera_inputs
-                        .before(camera_controller::<P>)
-                        .run_if(|input: Res<CameraInput>| !input.defaults_disabled),
-                    nearest_objects.before(camera_controller::<P>),
-                    camera_controller::<P>.before(TransformSystem::TransformPropagate),
-                )
-                    .in_base_set(CoreSet::PostUpdate),
-            );
+        app.init_resource::<CameraInput>().add_systems(
+            (
+                default_camera_inputs
+                    .before(camera_controller::<P>)
+                    .run_if(|input: Res<CameraInput>| !input.defaults_disabled),
+                nearest_objects.before(camera_controller::<P>),
+                camera_controller::<P>.before(TransformSystem::TransformPropagate),
+            )
+                .in_base_set(CoreSet::PostUpdate),
+        );
     }
 }
 

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -3,7 +3,6 @@
 use std::marker::PhantomData;
 
 use bevy::{
-    ecs::schedule::ShouldRun,
     input::mouse::MouseMotion,
     math::{DQuat, DVec3},
     prelude::*,
@@ -18,23 +17,18 @@ use crate::{precision::GridPrecision, FloatingOriginSettings, GridCell};
 pub struct CameraControllerPlugin<P: GridPrecision>(PhantomData<P>);
 impl<P: GridPrecision> Plugin for CameraControllerPlugin<P> {
     fn build(&self, app: &mut App) {
-        app.init_resource::<CameraInput>().add_system_set_to_stage(
-            CoreStage::PostUpdate,
-            SystemSet::new()
-                .with_system(
+        app.init_resource::<CameraInput>()
+            //CoreStage::PostUpdate,
+            .add_systems(
+                (
                     default_camera_inputs
                         .before(camera_controller::<P>)
-                        .with_run_criteria(|input: Res<CameraInput>| {
-                            if input.defaults_disabled {
-                                ShouldRun::No
-                            } else {
-                                ShouldRun::Yes
-                            }
-                        }),
+                        .run_if(|input: Res<CameraInput>| !input.defaults_disabled),
+                    nearest_objects.before(camera_controller::<P>),
+                    camera_controller::<P>.before(TransformSystem::TransformPropagate),
                 )
-                .with_system(nearest_objects.before(camera_controller::<P>))
-                .with_system(camera_controller::<P>.before(TransformSystem::TransformPropagate)),
-        );
+                    .in_base_set(CoreSet::PostUpdate),
+            );
     }
 }
 

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -13,10 +13,10 @@ pub struct FloatingOriginDebugPlugin<P: GridPrecision>(PhantomData<P>);
 impl<P: GridPrecision> Plugin for FloatingOriginDebugPlugin<P> {
     fn build(&self, app: &mut App) {
         app.add_plugin(bevy_polyline::PolylinePlugin)
-            .add_system_to_stage(CoreStage::Update, build_cube)
-            .add_system_to_stage(
-                CoreStage::PostUpdate,
+            .add_system(build_cube.in_base_set(CoreSet::Update))
+            .add_system(
                 update_debug_bounds::<P>
+                    .in_base_set(CoreSet::PostUpdate)
                     .after(crate::recenter_transform_on_grid::<P>)
                     .before(crate::update_global_from_grid::<P>),
             );
@@ -58,7 +58,7 @@ pub fn update_debug_bounds<P: GridPrecision>(
             *polyline = cube_polyline.polyline.clone();
         }
         if let Some((occupied_cell, has_origin)) = occupied_cells.next() {
-            visibility.is_visible = true;
+            *visibility = Visibility::Visible;
             *cell = *occupied_cell;
             if has_origin.is_some() {
                 *matl = cube_polyline.origin_matl.clone();
@@ -67,7 +67,7 @@ pub fn update_debug_bounds<P: GridPrecision>(
             }
         } else {
             // If there are more debug bounds than occupied cells, hide the extras.
-            visibility.is_visible = false;
+            *visibility = Visibility::Hidden;
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,18 +135,20 @@ impl<P: GridPrecision> Plugin for FloatingOriginPlugin<P> {
             // add transform systems to startup so the first update is "correct"
             .add_startup_systems(
                 (
-                    recenter_transform_on_grid::<P>.before(update_global_from_grid::<P>),
-                    update_global_from_grid::<P>.before(transform_propagate_system::<P>),
+                    recenter_transform_on_grid::<P>,
+                    update_global_from_grid::<P>,
                     transform_propagate_system::<P>,
                 )
+                    .chain()
                     .in_set(TransformSystem::TransformPropagate),
             )
             .add_systems(
                 (
-                    recenter_transform_on_grid::<P>.before(update_global_from_grid::<P>),
-                    update_global_from_grid::<P>.before(transform_propagate_system::<P>),
+                    recenter_transform_on_grid::<P>,
+                    update_global_from_grid::<P>,
                     transform_propagate_system::<P>,
                 )
+                    .chain()
                     .in_set(TransformSystem::TransformPropagate),
             );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,6 @@ impl<P: GridPrecision> Plugin for FloatingOriginPlugin<P> {
                 )
                     .in_set(TransformSystem::TransformPropagate),
             )
-            //
             .add_systems(
                 (
                     recenter_transform_on_grid::<P>.before(update_global_from_grid::<P>),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,38 +126,29 @@ impl<P: GridPrecision> Plugin for FloatingOriginPlugin<P> {
             .register_type::<GlobalTransform>()
             .register_type::<GridCell<P>>()
             .add_plugin(ValidParentCheckPlugin::<GlobalTransform>::default())
+            .configure_set(TransformSystem::TransformPropagate.in_base_set(CoreSet::PostUpdate))
+            .edit_schedule(CoreSchedule::Startup, |schedule| {
+                schedule.configure_set(
+                    TransformSystem::TransformPropagate.in_base_set(StartupSet::PostStartup),
+                );
+            })
             // add transform systems to startup so the first update is "correct"
-            .add_startup_system_to_stage(
-                StartupStage::PostStartup,
-                recenter_transform_on_grid::<P>
-                    .label(TransformSystem::TransformPropagate)
-                    .before(update_global_from_grid::<P>),
+            .add_startup_systems(
+                (
+                    recenter_transform_on_grid::<P>.before(update_global_from_grid::<P>),
+                    update_global_from_grid::<P>.before(transform_propagate_system::<P>),
+                    transform_propagate_system::<P>,
+                )
+                    .in_set(TransformSystem::TransformPropagate),
             )
-            .add_startup_system_to_stage(
-                StartupStage::PostStartup,
-                update_global_from_grid::<P>
-                    .label(TransformSystem::TransformPropagate)
-                    .before(transform_propagate_system::<P>),
-            )
-            .add_startup_system_to_stage(
-                StartupStage::PostStartup,
-                transform_propagate_system::<P>.label(TransformSystem::TransformPropagate),
-            )
-            .add_system_to_stage(
-                CoreStage::PostUpdate,
-                recenter_transform_on_grid::<P>
-                    .label(TransformSystem::TransformPropagate)
-                    .before(update_global_from_grid::<P>),
-            )
-            .add_system_to_stage(
-                CoreStage::PostUpdate,
-                update_global_from_grid::<P>
-                    .label(TransformSystem::TransformPropagate)
-                    .before(transform_propagate_system::<P>),
-            )
-            .add_system_to_stage(
-                CoreStage::PostUpdate,
-                transform_propagate_system::<P>.label(TransformSystem::TransformPropagate),
+            //
+            .add_systems(
+                (
+                    recenter_transform_on_grid::<P>.before(update_global_from_grid::<P>),
+                    update_global_from_grid::<P>.before(transform_propagate_system::<P>),
+                    transform_propagate_system::<P>,
+                )
+                    .in_set(TransformSystem::TransformPropagate),
             );
     }
 }
@@ -380,16 +371,18 @@ pub fn recenter_transform_on_grid<P: GridPrecision>(
     settings: Res<FloatingOriginSettings>,
     mut query: Query<(&mut GridCell<P>, &mut Transform), (Changed<Transform>, Without<Parent>)>,
 ) {
-    query.par_for_each_mut(1024, |(mut grid_pos, mut transform)| {
-        if transform.as_ref().translation.abs().max_element()
-            > settings.maximum_distance_from_origin
-        {
-            let (grid_cell_delta, translation) =
-                settings.imprecise_translation_to_grid(transform.as_ref().translation);
-            *grid_pos = *grid_pos + grid_cell_delta;
-            transform.translation = translation;
-        }
-    });
+    query
+        .par_iter_mut()
+        .for_each_mut(|(mut grid_pos, mut transform)| {
+            if transform.as_ref().translation.abs().max_element()
+                > settings.maximum_distance_from_origin
+            {
+                let (grid_cell_delta, translation) =
+                    settings.imprecise_translation_to_grid(transform.as_ref().translation);
+                *grid_pos = *grid_pos + grid_cell_delta;
+                transform.translation = translation;
+            }
+        });
 }
 
 /// Compute the `GlobalTransform` relative to the floating origin.
@@ -408,14 +401,18 @@ pub fn update_global_from_grid<P: GridPrecision>(
 
     if origin_grid_pos_changed {
         let mut all_entities = entities.p1();
-        all_entities.par_for_each_mut(1024, |(local, global, entity_cell)| {
-            update_global_from_cell_local(&settings, entity_cell, origin_cell, local, global);
-        });
+        all_entities
+            .par_iter_mut()
+            .for_each_mut(|(local, global, entity_cell)| {
+                update_global_from_cell_local(&settings, entity_cell, origin_cell, local, global);
+            });
     } else {
         let mut moved_cell_entities = entities.p0();
-        moved_cell_entities.par_for_each_mut(1024, |(local, global, entity_cell)| {
-            update_global_from_cell_local(&settings, entity_cell, origin_cell, local, global);
-        });
+        moved_cell_entities
+            .par_iter_mut()
+            .for_each_mut(|(local, global, entity_cell)| {
+                update_global_from_cell_local(&settings, entity_cell, origin_cell, local, global);
+            });
     }
 }
 


### PR DESCRIPTION
Really cool plugin, but sadly not updated to bevy 0.10, so I tried :)

Updated the plugin to bevy 0.10, latest polyline and framepace as well. 
Had to add some extra features to dev-dependencies because of the examples. 
Used bevy's default par_iter() introduced in 0.10. I have not done any benchmarking or anything, you might want to change this.