### PR TITLE
Bevy 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ documentation = "https://docs.rs/crate/big_space/latest"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = { version = "0.11", default_features = false }
+bevy = { version = "0.12", default_features = false }
 
 [dev-dependencies]
-bevy = "0.11"
-bevy_framepace = { version = "0.13", default-features = false }
+bevy = "0.12"
+#bevy_framepace = { version = "0.13", default-features = false }
 
 [features]
 default = ["debug", "camera"]

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ I intend to track the `main` branch of Bevy. PRs supporting this are welcome!
 
 | bevy | big_space |
 | ---- | --------- |
+| 0.12 | 0.4 (*unreleased*)       |
 | 0.11 | 0.3       |
 | 0.10 | 0.2       |
 | 0.9  | 0.1       |

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -15,7 +15,7 @@ fn main() {
             big_space::FloatingOriginPlugin::<i128>::default(),
             big_space::debug::FloatingOriginDebugPlugin::<i128>::default(),
             big_space::camera::CameraControllerPlugin::<i128>::default(),
-            bevy_framepace::FramepacePlugin,
+            //bevy_framepace::FramepacePlugin,
         ))
         .insert_resource(ClearColor(Color::BLACK))
         .add_systems(Startup, (setup, ui_setup))

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -164,7 +164,7 @@ pub fn default_camera_inputs(
     keyboard
         .pressed(KeyCode::ShiftLeft)
         .then(|| cam.boost = true);
-    if let Some(total_mouse_motion) = mouse_move.iter().map(|e| e.delta).reduce(|sum, i| sum + i) {
+    if let Some(total_mouse_motion) = mouse_move.read().map(|e| e.delta).reduce(|sum, i| sum + i) {
         cam.pitch += total_mouse_motion.y as f64 * -0.1;
         cam.yaw += total_mouse_motion.x as f64 * -0.1;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,8 +273,10 @@ impl FloatingOriginSettings {
 pub struct FloatingSpatialBundle<P: GridPrecision> {
     /// The visibility of the entity.
     pub visibility: Visibility,
-    /// The computed visibility of the entity.
-    pub computed: ComputedVisibility,
+    /// The inhereted visibility of the entity.
+    pub inhereted: InheritedVisibility,
+    /// The view visibility of the entity.
+    pub view: ViewVisibility,
     /// The transform of the entity.
     pub transform: Transform,
     /// The global transform of the entity.
@@ -296,7 +298,7 @@ pub fn recenter_transform_on_grid<P: GridPrecision>(
 ) {
     query
         .par_iter_mut()
-        .for_each_mut(|(mut grid_pos, mut transform)| {
+        .for_each(|(mut grid_pos, mut transform)| {
             if transform.as_ref().translation.abs().max_element()
                 > settings.maximum_distance_from_origin
             {
@@ -326,14 +328,14 @@ pub fn update_global_from_grid<P: GridPrecision>(
         let mut all_entities = entities.p1();
         all_entities
             .par_iter_mut()
-            .for_each_mut(|(local, global, entity_cell)| {
+            .for_each(|(local, global, entity_cell)| {
                 update_global_from_cell_local(&settings, entity_cell, &origin_cell, local, global);
             });
     } else {
         let mut moved_cell_entities = entities.p0();
         moved_cell_entities
             .par_iter_mut()
-            .for_each_mut(|(local, global, entity_cell)| {
+            .for_each(|(local, global, entity_cell)| {
                 update_global_from_cell_local(&settings, entity_cell, &origin_cell, local, global);
             });
     }
@@ -368,7 +370,7 @@ pub fn sync_simple_transforms<P: GridPrecision>(
 ) {
     query
         .par_iter_mut()
-        .for_each_mut(|(transform, mut global_transform)| {
+        .for_each(|(transform, mut global_transform)| {
             *global_transform = GlobalTransform::from(*transform);
         });
 }


### PR DESCRIPTION
Update to 0.12

`bevy_framespace` was not included, but since it was only added for the examples and is not actually used, this should not be a problem.