### PR TITLE
Use get_single instead of single

### DIFF
--- a/src/debug.rs
+++ b/src/debug.rs
@@ -27,7 +27,9 @@ pub fn update_debug_bounds<P: GridPrecision>(
     occupied_cells: Query<&GridCell<P>, Without<FloatingOrigin>>,
     origin_cells: Query<&GridCell<P>, With<FloatingOrigin>>,
 ) {
-    let origin_cell = origin_cells.single();
+    let Ok(origin_cell) = origin_cells.get_single() else {
+        return;
+    };
     for cell in occupied_cells.iter() {
         let cell = cell - origin_cell;
         let scale = Vec3::splat(settings.grid_edge_length * 0.999);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -322,7 +322,9 @@ pub fn update_global_from_grid<P: GridPrecision>(
         Query<(GridTransformReadOnly<P>, &mut GlobalTransform)>,
     )>,
 ) {
-    let (origin_cell, floating_origin) = origin.single();
+    let Ok((origin_cell, floating_origin)) = origin.get_single() else {
+        return;
+    };
 
     if origin_cell.is_changed() || floating_origin.is_changed() {
         let mut all_entities = entities.p1();


### PR DESCRIPTION
`big_space` currently panics if you defer creation of the floating origin. Using `get_single` instead of `single` prevents this.