### PR TITLE
Bevy 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,23 +9,23 @@ repository = "https://github.com/aevyrie/big_space"
 documentation = "https://docs.rs/crate/big_space/latest"
 
 [dependencies]
-bevy_app = { version = "0.14.0", default-features = false }
-bevy_ecs = { version = "0.14.0", default-features = false }
-bevy_hierarchy = { version = "0.14.0", default-features = false }
-bevy_log = { version = "0.14.0", default-features = false }
-bevy_math = { version = "0.14.0", default-features = false }
-bevy_reflect = { version = "0.14.0", default-features = false }
-bevy_transform = { version = "0.14.0", default-features = false }
-bevy_utils = { version = "0.14.0", default-features = false }
+bevy_app = { version = "0.15.0-rc", default-features = false }
+bevy_ecs = { version = "0.15.0-rc", default-features = false }
+bevy_hierarchy = { version = "0.15.0-rc", default-features = false }
+bevy_log = { version = "0.15.0-rc", default-features = false }
+bevy_math = { version = "0.15.0-rc", default-features = false }
+bevy_reflect = { version = "0.15.0-rc", default-features = false }
+bevy_transform = { version = "0.15.0-rc", default-features = false }
+bevy_utils = { version = "0.15.0-rc", default-features = false }
 # Optional
-bevy_color = { version = "0.14.0", default-features = false, optional = true }
-bevy_gizmos = { version = "0.14.0", default-features = false, optional = true }
-bevy_render = { version = "0.14.0", default-features = false, optional = true }
-bevy_input = { version = "0.14.0", default-features = false, optional = true }
-bevy_time = { version = "0.14.0", default-features = false, optional = true }
+bevy_color = { version = "0.15.0-rc", default-features = false, optional = true }
+bevy_gizmos = { version = "0.15.0-rc", default-features = false, optional = true }
+bevy_render = { version = "0.15.0-rc", default-features = false, optional = true }
+bevy_input = { version = "0.15.0-rc", default-features = false, optional = true }
+bevy_time = { version = "0.15.0-rc", default-features = false, optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.14.0", default-features = false, features = [
+bevy = { version = "0.15.0-rc", default-features = false, features = [
     "bevy_scene",
     "bevy_gltf",
     "bevy_winit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,23 +9,23 @@ repository = "https://github.com/aevyrie/big_space"
 documentation = "https://docs.rs/crate/big_space/latest"
 
 [dependencies]
-bevy_app = { version = "0.15.0-rc", default-features = false }
-bevy_ecs = { version = "0.15.0-rc", default-features = false }
-bevy_hierarchy = { version = "0.15.0-rc", default-features = false }
-bevy_log = { version = "0.15.0-rc", default-features = false }
-bevy_math = { version = "0.15.0-rc", default-features = false }
-bevy_reflect = { version = "0.15.0-rc", default-features = false }
-bevy_transform = { version = "0.15.0-rc", default-features = false }
-bevy_utils = { version = "0.15.0-rc", default-features = false }
+bevy_app = { version = "0.15.0", default-features = false }
+bevy_ecs = { version = "0.15.0", default-features = false }
+bevy_hierarchy = { version = "0.15.0", default-features = false }
+bevy_log = { version = "0.15.0", default-features = false }
+bevy_math = { version = "0.15.0", default-features = false }
+bevy_reflect = { version = "0.15.0", default-features = false }
+bevy_transform = { version = "0.15.0", default-features = false }
+bevy_utils = { version = "0.15.0", default-features = false }
 # Optional
-bevy_color = { version = "0.15.0-rc", default-features = false, optional = true }
-bevy_gizmos = { version = "0.15.0-rc", default-features = false, optional = true }
-bevy_render = { version = "0.15.0-rc", default-features = false, optional = true }
-bevy_input = { version = "0.15.0-rc", default-features = false, optional = true }
-bevy_time = { version = "0.15.0-rc", default-features = false, optional = true }
+bevy_color = { version = "0.15.0", default-features = false, optional = true }
+bevy_gizmos = { version = "0.15.0", default-features = false, optional = true }
+bevy_render = { version = "0.15.0", default-features = false, optional = true }
+bevy_input = { version = "0.15.0", default-features = false, optional = true }
+bevy_time = { version = "0.15.0", default-features = false, optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.15.0-rc", default-features = false, features = [
+bevy = { version = "0.15.0", default-features = false, features = [
     "bevy_scene",
     "bevy_gltf",
     "bevy_winit",
@@ -33,11 +33,12 @@ bevy = { version = "0.15.0-rc", default-features = false, features = [
     "bevy_ui",
     "bevy_pbr",
     "bevy_gizmos",
+    "animation",
+    "bevy_window",
     "x11",
     "tonemapping_luts",
     "multi_threaded",
 ] }
-# bevy-inspector-egui = "0.24"
 rand = "0.8.5"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ From the docs: https://docs.rs/big_space/latest/big_space/precision/trait.GridPr
 
 | bevy | big_space |
 | ---- | --------- |
+| 0.15 | 0.8       |
 | 0.14 | 0.7       |
 | 0.13 | 0.5, 0.6  |
 | 0.12 | 0.4       |

--- a/examples/debug.rs
+++ b/examples/debug.rs
@@ -30,8 +30,8 @@ fn movement(
     )>,
 ) {
     let delta_translation = |offset: f32, scale: f32| -> Vec3 {
-        let t_1 = time.elapsed_seconds() * 0.1 + offset;
-        let dt = time.delta_seconds() * 0.1;
+        let t_1 = time.elapsed_secs() * 0.1 + offset;
+        let dt = time.delta_secs() * 0.1;
         let t_0 = t_1 - dt;
         let pos =
             |t: f32| -> Vec3 { Vec3::new(t.cos() * 2.0, t.sin() * 2.0, (t * 1.3).sin() * 2.0) };
@@ -51,7 +51,7 @@ struct Rotator;
 
 fn rotation(time: Res<Time>, mut query: Query<&mut Transform, With<Rotator>>) {
     for mut transform in &mut query {
-        transform.rotate_z(3.0 * time.delta_seconds() * 0.2);
+        transform.rotate_z(3.0 * time.delta_secs() * 0.2);
     }
 }
 
@@ -68,60 +68,42 @@ fn setup(
 
     commands.spawn_big_space(ReferenceFrame::<i64>::new(1.0, 0.01), |root| {
         root.spawn_spatial((
-            PbrBundle {
-                mesh: mesh_handle.clone(),
-                material: matl_handle.clone(),
-                transform: Transform::from_xyz(0.0, 0.0, 1.0),
-                ..default()
-            },
+            Mesh3d(mesh_handle.clone()),
+            MeshMaterial3d(matl_handle.clone()),
+            Transform::from_xyz(0.0, 0.0, 1.0),
             Mover::<1>,
         ));
 
         root.spawn_spatial((
-            PbrBundle {
-                mesh: mesh_handle.clone(),
-                material: matl_handle.clone(),
-                transform: Transform::from_xyz(1.0, 0.0, 0.0),
-                ..default()
-            },
+            Mesh3d(mesh_handle.clone()),
+            MeshMaterial3d(matl_handle.clone()),
+            Transform::from_xyz(1.0, 0.0, 0.0),
             Mover::<2>,
         ));
 
         root.with_frame(ReferenceFrame::new(0.2, 0.01), |new_frame| {
             new_frame.insert((
-                PbrBundle {
-                    mesh: mesh_handle.clone(),
-                    material: matl_handle.clone(),
-                    transform: Transform::from_xyz(0.0, 1.0, 0.0),
-                    ..default()
-                },
+                Mesh3d(mesh_handle.clone()),
+                MeshMaterial3d(matl_handle.clone()),
+                Transform::from_xyz(0.0, 1.0, 0.0),
                 Rotator,
                 Mover::<3>,
             ));
             new_frame.spawn_spatial((
-                PbrBundle {
-                    mesh: mesh_handle,
-                    material: matl_handle,
-                    transform: Transform::from_xyz(0.0, 0.5, 0.0),
-                    ..default()
-                },
+                Mesh3d(mesh_handle),
+                MeshMaterial3d(matl_handle),
+                Transform::from_xyz(0.0, 0.5, 0.0),
                 Mover::<4>,
             ));
         });
 
         // light
-        root.spawn_spatial((PointLightBundle {
-            transform: Transform::from_xyz(4.0, 8.0, 4.0),
-            ..default()
-        },));
+        root.spawn_spatial((PointLight::default(), Transform::from_xyz(4.0, 8.0, 4.0)));
 
         // camera
         root.spawn_spatial((
-            Camera3dBundle {
-                transform: Transform::from_xyz(0.0, 0.0, 8.0)
-                    .looking_at(Vec3::new(0.0, 0.0, 0.0), Vec3::Y),
-                ..default()
-            },
+            Camera3d::default(),
+            Transform::from_xyz(0.0, 0.0, 8.0).looking_at(Vec3::new(0.0, 0.0, 0.0), Vec3::Y),
             FloatingOrigin,
         ));
     });

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -37,15 +37,12 @@ fn setup(
 ) {
     commands.spawn_big_space(ReferenceFrame::<i128>::default(), |root| {
         root.spawn_spatial((
-            Camera3dBundle {
-                transform: Transform::from_xyz(0.0, 0.0, 8.0)
-                    .looking_at(Vec3::new(0.0, 0.0, 0.0), Vec3::Y),
-                projection: Projection::Perspective(PerspectiveProjection {
-                    near: 1e-18,
-                    ..default()
-                }),
+            Camera3d::default(),
+            Projection::Perspective(PerspectiveProjection {
+                near: 1e-18,
                 ..default()
-            },
+            }),
+            Transform::from_xyz(0.0, 0.0, 8.0).looking_at(Vec3::new(0.0, 0.0, 0.0), Vec3::Y),
             FloatingOrigin, // Important: marks the floating origin entity for rendering.
             CameraController::default() // Built-in camera controller
                 .with_speed_bounds([10e-18, 10e35])
@@ -68,20 +65,16 @@ fn setup(
             translation.x += j / 2.0 + k;
             translation.y = j / 2.0;
 
-            root.spawn_spatial(PbrBundle {
-                mesh: mesh_handle.clone(),
-                material: matl_handle.clone(),
-                transform: Transform::from_scale(Vec3::splat(j)).with_translation(translation),
-                ..default()
-            });
+            root.spawn_spatial((
+                Mesh3d(mesh_handle.clone()),
+                MeshMaterial3d(matl_handle.clone()),
+                Transform::from_scale(Vec3::splat(j)).with_translation(translation),
+            ));
         }
 
         // light
-        root.spawn_spatial(DirectionalLightBundle {
-            directional_light: DirectionalLight {
-                illuminance: 10_000.0,
-                ..default()
-            },
+        root.spawn_spatial(DirectionalLight {
+            illuminance: 10_000.0,
             ..default()
         });
     });
@@ -95,41 +88,37 @@ pub struct FunFactText;
 
 fn ui_setup(mut commands: Commands) {
     commands.spawn((
-        TextBundle::from_section(
-            "",
-            TextStyle {
-                font_size: 18.0,
-                color: Color::WHITE,
-                ..default()
-            },
-        )
-        .with_text_justify(JustifyText::Left)
-        .with_style(Style {
+        Text::default(),
+        TextFont {
+            font_size: 18.0,
+            ..default()
+        },
+        TextColor(Color::WHITE),
+        TextLayout::new_with_justify(JustifyText::Left),
+        Node {
             position_type: PositionType::Absolute,
             top: Val::Px(10.0),
             left: Val::Px(10.0),
             ..default()
-        }),
+        },
         BigSpaceDebugText,
     ));
 
     commands.spawn((
-        TextBundle::from_section(
-            "",
-            TextStyle {
-                font_size: 52.0,
-                color: Color::WHITE,
-                ..default()
-            },
-        )
-        .with_style(Style {
+        Text::default(),
+        TextFont {
+            font_size: 52.0,
+            ..default()
+        },
+        TextColor(Color::WHITE),
+        TextLayout::new_with_justify(JustifyText::Center),
+        Node {
             position_type: PositionType::Absolute,
             bottom: Val::Px(10.0),
             right: Val::Px(10.0),
             left: Val::Px(10.0),
             ..default()
-        })
-        .with_text_justify(JustifyText::Center),
+        },
         FunFactText,
     ));
 }
@@ -150,7 +139,6 @@ fn highlight_nearest_sphere(
     gizmos
         .sphere(
             translation,
-            Quat::IDENTITY, // Bevy likes to explode on non-normalized quats in gizmos,
             scale.x * 0.505,
             Color::Srgba(palettes::basic::RED),
         )
@@ -168,7 +156,7 @@ fn ui_text_system(
     time: Res<Time>,
     origin: Query<(Entity, GridTransformReadOnly<i128>), With<FloatingOrigin>>,
     camera: Query<&CameraController>,
-    objects: Query<&Transform, With<Handle<Mesh>>>,
+    objects: Query<&Transform, With<Mesh3d>>,
 ) {
     let (origin_entity, origin_pos) = origin.single();
     let translation = origin_pos.transform.translation;
@@ -198,7 +186,7 @@ fn ui_text_system(
     );
 
     let velocity = camera.single().velocity();
-    let speed = velocity.0.length() / time.delta_seconds_f64();
+    let speed = velocity.0.length() / time.delta_secs_f64();
     let camera_text = if speed > 3.0e8 {
         format!("Speed: {:.0e} * speed of light", speed / 3.0e8)
     } else {
@@ -222,11 +210,11 @@ fn ui_text_system(
 
     let mut debug_text = debug_text.single_mut();
 
-    debug_text.0.sections[0].value = format!(
+    debug_text.0.0 = format!(
         "{grid_text}\n{translation_text}\n\n{real_position_f64_text}\n{real_position_f32_text}\n\n{camera_text}\n{nearest_text}"
     );
 
-    fun_text.single_mut().sections[0].value = fact_text
+    fun_text.single_mut().0 = fact_text
 }
 
 fn closest<'a>(diameter: f32) -> (f32, &'a str) {
@@ -282,15 +270,15 @@ fn cursor_grab_system(
     };
 
     if btn.just_pressed(MouseButton::Left) {
-        window.cursor.grab_mode = CursorGrabMode::Locked;
-        window.cursor.visible = false;
+        window.cursor_options.grab_mode = CursorGrabMode::Locked;
+        window.cursor_options.visible = false;
         // window.mode = WindowMode::BorderlessFullscreen;
         cam.defaults_disabled = false;
     }
 
     if key.just_pressed(KeyCode::Escape) {
-        window.cursor.grab_mode = CursorGrabMode::None;
-        window.cursor.visible = true;
+        window.cursor_options.grab_mode = CursorGrabMode::None;
+        window.cursor_options.visible = true;
         // window.mode = WindowMode::Windowed;
         cam.defaults_disabled = true;
     }

--- a/examples/error.rs
+++ b/examples/error.rs
@@ -129,12 +129,10 @@ fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
             distant_grid_cell,
             Rotator,
         ))
-        .with_children(|parent| {
-            parent.spawn((
-                SceneRoot(asset_server.load("models/low_poly_spaceship/scene.gltf#Scene0")),
-                Transform::from_xyz(0.0, 0.0, 20.0),
-            ));
-        });
+        .with_child((
+            SceneRoot(asset_server.load("models/low_poly_spaceship/scene.gltf#Scene0")),
+            Transform::from_xyz(0.0, 0.0, 20.0),
+        ));
         // light
         root.spawn_spatial((
             DirectionalLight::default(),

--- a/examples/error.rs
+++ b/examples/error.rs
@@ -84,7 +84,7 @@ fn toggle_plugin(
             .join(",") // separator
     };
 
-    text.single_mut().sections[0].value =
+    text.single_mut().0 =
         format!("Press Spacebar to toggle: {msg}\nCamera distance to floating origin: {}\nMesh distance from origin: {}", thousands(dist), thousands(DISTANCE))
 }
 
@@ -93,26 +93,24 @@ struct Rotator;
 
 fn rotator_system(time: Res<Time>, mut query: Query<&mut Transform, With<Rotator>>) {
     for mut transform in &mut query {
-        transform.rotate_y(time.delta_seconds());
+        transform.rotate_y(time.delta_secs());
     }
 }
 
 fn setup_ui(mut commands: Commands) {
-    commands.spawn(
-        TextBundle::from_section(
-            "",
-            TextStyle {
-                font_size: 30.0,
-                ..default()
-            },
-        )
-        .with_style(Style {
+    commands.spawn((
+        Text::default(),
+        TextFont {
+            font_size: 30.0,
+            ..default()
+        },
+        Node {
             position_type: PositionType::Absolute,
             top: Val::Px(12.0),
             left: Val::Px(12.0),
             ..default()
-        }),
-    );
+        },
+    ));
 }
 
 fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
@@ -126,35 +124,27 @@ fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
         root.spawn_spatial((distant_grid_cell, FloatingOrigin));
 
         root.spawn_spatial((
-            SceneBundle {
-                scene: asset_server.load("models/low_poly_spaceship/scene.gltf#Scene0"),
-                transform: Transform::from_scale(Vec3::splat(0.2)),
-                ..default()
-            },
+            SceneRoot(asset_server.load("models/low_poly_spaceship/scene.gltf#Scene0")),
+            Transform::from_scale(Vec3::splat(0.2)),
             distant_grid_cell,
             Rotator,
         ))
         .with_children(|parent| {
-            parent.spawn(SceneBundle {
-                scene: asset_server.load("models/low_poly_spaceship/scene.gltf#Scene0"),
-                transform: Transform::from_xyz(0.0, 0.0, 20.0),
-                ..default()
-            });
+            parent.spawn((
+                SceneRoot(asset_server.load("models/low_poly_spaceship/scene.gltf#Scene0")),
+                Transform::from_xyz(0.0, 0.0, 20.0),
+            ));
         });
         // light
         root.spawn_spatial((
-            DirectionalLightBundle {
-                transform: Transform::from_xyz(4.0, -10.0, -4.0),
-                ..default()
-            },
+            DirectionalLight::default(),
+            Transform::from_xyz(4.0, -10.0, -4.0),
             distant_grid_cell,
         ));
         // camera
         root.spawn_spatial((
-            Camera3dBundle {
-                transform: Transform::from_xyz(8.0, 8.0, 0.0).looking_at(Vec3::ZERO, Vec3::Y),
-                ..default()
-            },
+            Camera3d::default(),
+            Transform::from_xyz(8.0, 8.0, 0.0).looking_at(Vec3::ZERO, Vec3::Y),
             distant_grid_cell,
         ));
     });

--- a/examples/error_child.rs
+++ b/examples/error_child.rs
@@ -36,12 +36,11 @@ fn setup_scene(
     commands.spawn_big_space(
         ReferenceFrame::<i64>::new(SPHERE_RADIUS * 100.0, 0.0),
         |root_frame| {
-            root_frame.spawn_spatial(PbrBundle {
-                mesh: mesh_handle.clone(),
-                material: materials.add(Color::from(palettes::css::BLUE)),
-                transform: Transform::from_translation(NEARBY),
-                ..default()
-            });
+            root_frame.spawn_spatial((
+                Mesh3d(mesh_handle.clone()),
+                MeshMaterial3d(materials.add(Color::from(palettes::css::BLUE))),
+                Transform::from_translation(NEARBY),
+            ));
 
             let parent = root_frame.frame().translation_to_grid(DISTANT);
             root_frame.with_frame(
@@ -52,12 +51,11 @@ fn setup_scene(
                     let child = parent_frame
                         .frame()
                         .translation_to_grid(-DISTANT + NEARBY.as_dvec3());
-                    parent_frame.insert(PbrBundle {
-                        mesh: mesh_handle.clone(),
-                        material: matl_handle.clone(),
-                        transform: Transform::from_translation(parent.1),
-                        ..default()
-                    });
+                    parent_frame.insert((
+                        Mesh3d(mesh_handle.clone()),
+                        MeshMaterial3d(matl_handle.clone()),
+                        Transform::from_translation(parent.1),
+                    ));
                     parent_frame.insert(parent.0);
 
                     parent_frame.with_children(|child_builder| {
@@ -68,35 +66,28 @@ fn setup_scene(
                         // Note that the sphere does not have any rendering artifacts, its position
                         // just has a fixed error.
                         child_builder.spawn((
-                            PbrBundle {
-                                mesh: mesh_handle,
-                                material: materials.add(Color::from(palettes::css::GREEN)),
-                                transform: Transform::from_translation(child.1),
-                                ..default()
-                            },
+                            Mesh3d(mesh_handle),
+                            MeshMaterial3d(materials.add(Color::from(palettes::css::GREEN))),
+                            Transform::from_translation(child.1),
                             child.0,
                         ));
                     });
                 },
             );
 
-            root_frame.spawn_spatial(DirectionalLightBundle {
-                transform: Transform::from_xyz(4.0, -10.0, -4.0),
-                ..default()
-            });
+            root_frame.spawn_spatial((
+                DirectionalLight::default(),
+                Transform::from_xyz(4.0, -10.0, -4.0),
+            ));
 
             root_frame.spawn_spatial((
-                Camera3dBundle {
-                    transform: Transform::from_translation(
-                        NEARBY + Vec3::new(0.0, 0.0, SPHERE_RADIUS * 10.0),
-                    )
+                Camera3d::default(),
+                Transform::from_translation(NEARBY + Vec3::new(0.0, 0.0, SPHERE_RADIUS * 10.0))
                     .looking_at(NEARBY, Vec3::Y),
-                    projection: Projection::Perspective(PerspectiveProjection {
-                        near: (SPHERE_RADIUS * 0.1).min(0.1),
-                        ..default()
-                    }),
+                Projection::Perspective(PerspectiveProjection {
+                    near: (SPHERE_RADIUS * 0.1).min(0.1),
                     ..default()
-                },
+                }),
                 FloatingOrigin,
                 big_space::camera::CameraController::default() // Built-in camera controller
                     .with_speed_bounds([10e-18, 10e35])

--- a/examples/error_child.rs
+++ b/examples/error_child.rs
@@ -58,20 +58,18 @@ fn setup_scene(
                     ));
                     parent_frame.insert(parent.0);
 
-                    parent_frame.with_children(|child_builder| {
-                        // A green sphere that is a child of the sphere very far from the origin.
-                        // This child is very far from its parent, and should be located exactly at
-                        // the origin (if there was no floating point error). The distance from the
-                        // green sphere to the red sphere is the error caused by float imprecision.
-                        // Note that the sphere does not have any rendering artifacts, its position
-                        // just has a fixed error.
-                        child_builder.spawn((
-                            Mesh3d(mesh_handle),
-                            MeshMaterial3d(materials.add(Color::from(palettes::css::GREEN))),
-                            Transform::from_translation(child.1),
-                            child.0,
-                        ));
-                    });
+                    // A green sphere that is a child of the sphere very far from the origin.
+                    // This child is very far from its parent, and should be located exactly at
+                    // the origin (if there was no floating point error). The distance from the
+                    // green sphere to the red sphere is the error caused by float imprecision.
+                    // Note that the sphere does not have any rendering artifacts, its position
+                    // just has a fixed error.
+                    parent_frame.with_child((
+                        Mesh3d(mesh_handle),
+                        MeshMaterial3d(materials.add(Color::from(palettes::css::GREEN))),
+                        Transform::from_translation(child.1),
+                        child.0,
+                    ));
                 },
             );
 

--- a/examples/planets.rs
+++ b/examples/planets.rs
@@ -4,7 +4,7 @@ use std::collections::VecDeque;
 /// scale. The earth is rotating on its axis, and the camera is in this reference frame, to
 /// demonstrate how high precision nested reference frames work at large scales.
 use bevy::{
-    core_pipeline::bloom::BloomSettings,
+    core_pipeline::bloom::Bloom,
     math::DVec3,
     pbr::{CascadeShadowConfigBuilder, NotShadowCaster},
     prelude::*,
@@ -134,38 +134,32 @@ fn spawn_solar_system(
 
     commands.spawn((
         PrimaryLight,
-        DirectionalLightBundle {
-            directional_light: DirectionalLight {
-                color: Color::WHITE,
-                illuminance: 120_000.,
-                shadows_enabled: true,
-                ..default()
-            },
-            cascade_shadow_config: CascadeShadowConfigBuilder {
-                num_cascades: 4,
-                minimum_distance: 0.1,
-                maximum_distance: 10_000.0,
-                first_cascade_far_bound: 100.0,
-                overlap_proportion: 0.2,
-            }
-            .build(),
+        DirectionalLight {
+            color: Color::WHITE,
+            illuminance: 120_000.,
+            shadows_enabled: true,
             ..default()
         },
+        CascadeShadowConfigBuilder {
+            num_cascades: 4,
+            minimum_distance: 0.1,
+            maximum_distance: 10_000.0,
+            first_cascade_far_bound: 100.0,
+            overlap_proportion: 0.2,
+        }
+        .build(),
     ));
 
     commands.spawn_big_space(ReferenceFrame::<i64>::default(), |root_frame| {
         root_frame.with_frame_default(|sun| {
             sun.insert((Sun, Name::new("Sun")));
             sun.spawn_spatial((
-                PbrBundle {
-                    mesh: sun_mesh_handle,
-                    material: materials.add(StandardMaterial {
-                        base_color: Color::WHITE,
-                        emissive: LinearRgba::rgb(100000., 100000., 100000.),
-                        ..default()
-                    }),
+                Mesh3d(sun_mesh_handle),
+                MeshMaterial3d(materials.add(StandardMaterial {
+                    base_color: Color::WHITE,
+                    emissive: LinearRgba::rgb(100000., 100000., 100000.),
                     ..default()
-                },
+                })),
                 NotShadowCaster,
             ));
 
@@ -175,18 +169,15 @@ fn spawn_solar_system(
                 earth.insert((
                     Name::new("Earth"),
                     earth_cell,
-                    PbrBundle {
-                        mesh: earth_mesh_handle,
-                        material: materials.add(StandardMaterial {
-                            base_color: Color::Srgba(palettes::css::BLUE),
-                            perceptual_roughness: 0.8,
-                            reflectance: 1.0,
-                            ..default()
-                        }),
-                        transform: Transform::from_translation(earth_pos)
-                            .with_scale(Vec3::splat(EARTH_RADIUS_M as f32)),
+                    Mesh3d(earth_mesh_handle),
+                    MeshMaterial3d(materials.add(StandardMaterial {
+                        base_color: Color::Srgba(palettes::css::BLUE),
+                        perceptual_roughness: 0.8,
+                        reflectance: 1.0,
                         ..default()
-                    },
+                    })),
+                    Transform::from_translation(earth_pos)
+                        .with_scale(Vec3::splat(EARTH_RADIUS_M as f32)),
                     Rotates(0.000001),
                 ));
 
@@ -195,17 +186,14 @@ fn spawn_solar_system(
                 let (moon_cell, moon_pos) = earth.frame().translation_to_grid(moon_pos);
                 earth.spawn_spatial((
                     Name::new("Moon"),
-                    PbrBundle {
-                        mesh: moon_mesh_handle,
-                        material: materials.add(StandardMaterial {
-                            base_color: Color::Srgba(palettes::css::GRAY),
-                            perceptual_roughness: 1.0,
-                            reflectance: 0.0,
-                            ..default()
-                        }),
-                        transform: Transform::from_translation(moon_pos),
+                    Mesh3d(moon_mesh_handle),
+                    MeshMaterial3d(materials.add(StandardMaterial {
+                        base_color: Color::Srgba(palettes::css::GRAY),
+                        perceptual_roughness: 1.0,
+                        reflectance: 0.0,
                         ..default()
-                    },
+                    })),
+                    Transform::from_translation(moon_pos),
                     moon_cell,
                 ));
 
@@ -215,27 +203,25 @@ fn spawn_solar_system(
                 earth
                     .spawn_spatial((ball_cell, Transform::from_translation(ball_pos)))
                     .with_children(|children| {
-                        children.spawn((PbrBundle {
-                            mesh: ball_mesh_handle,
-                            material: materials.add(StandardMaterial {
+                        children.spawn((
+                            Mesh3d(ball_mesh_handle),
+                            MeshMaterial3d(materials.add(StandardMaterial {
                                 base_color: Color::WHITE,
                                 ..default()
-                            }),
-                            ..default()
-                        },));
+                            })),
+                        ));
 
-                        children.spawn((PbrBundle {
-                            mesh: plane_mesh_handle,
-                            material: materials.add(StandardMaterial {
+                        children.spawn((
+                            Mesh3d(plane_mesh_handle),
+                            MeshMaterial3d(materials.add(StandardMaterial {
                                 base_color: Color::Srgba(palettes::css::DARK_GREEN),
                                 perceptual_roughness: 1.0,
                                 reflectance: 0.0,
                                 ..default()
-                            }),
-                            transform: Transform::from_scale(Vec3::splat(100.0))
+                            })),
+                            Transform::from_scale(Vec3::splat(100.0))
                                 .with_translation(Vec3::X * -5.0),
-                            ..default()
-                        },));
+                        ));
                     });
 
                 let cam_pos = DVec3::X * (EARTH_RADIUS_M + 1.0);
@@ -252,29 +238,23 @@ fn spawn_solar_system(
 
                     camera.spawn_spatial((
                         FloatingOrigin,
-                        Camera3dBundle {
-                            transform: Transform::from_xyz(0.0, 4.0, 22.0),
-                            camera: Camera {
-                                hdr: true,
-                                ..default()
-                            },
-                            exposure: Exposure::SUNLIGHT,
+                        Camera3d::default(),
+                        Transform::from_xyz(0.0, 4.0, 22.0),
+                        Camera {
+                            hdr: true,
                             ..default()
                         },
-                        BloomSettings::default(),
+                        Exposure::SUNLIGHT,
+                        Bloom::default(),
                     ));
 
                     camera.with_children(|camera| {
                         camera.spawn((
                             Spaceship,
-                            SceneBundle {
-                                scene: asset_server
-                                    .load("models/low_poly_spaceship/scene.gltf#Scene0"),
-                                transform: Transform::from_rotation(Quat::from_rotation_y(
-                                    std::f32::consts::PI,
-                                )),
-                                ..default()
-                            },
+                            SceneRoot(
+                                asset_server.load("models/low_poly_spaceship/scene.gltf#Scene0"),
+                            ),
+                            Transform::from_rotation(Quat::from_rotation_y(std::f32::consts::PI)),
                         ));
                     });
                 });
@@ -290,8 +270,8 @@ fn spawn_solar_system(
         let mut rng = rand::thread_rng();
         (0..1000).for_each(|_| {
             root_frame.spawn_spatial((
-                star_mesh_handle.clone(),
-                star_mat.clone(),
+                Mesh3d(star_mesh_handle.clone()),
+                MeshMaterial3d(star_mat.clone()),
                 Transform::from_xyz(
                     (rng.gen::<f32>() - 0.5) * 1e14,
                     (rng.gen::<f32>() - 0.5) * 1e14,
@@ -313,15 +293,15 @@ fn cursor_grab_system(
     };
 
     if btn.just_pressed(MouseButton::Right) {
-        window.cursor.grab_mode = bevy::window::CursorGrabMode::Locked;
-        window.cursor.visible = false;
+        window.cursor_options.grab_mode = bevy::window::CursorGrabMode::Locked;
+        window.cursor_options.visible = false;
         // window.mode = WindowMode::BorderlessFullscreen;
         cam.defaults_disabled = false;
     }
 
     if key.just_pressed(KeyCode::Escape) {
-        window.cursor.grab_mode = bevy::window::CursorGrabMode::None;
-        window.cursor.visible = true;
+        window.cursor_options.grab_mode = bevy::window::CursorGrabMode::None;
+        window.cursor_options.visible = true;
         // window.mode = WindowMode::Windowed;
         cam.defaults_disabled = true;
     }

--- a/examples/planets.rs
+++ b/examples/planets.rs
@@ -248,15 +248,11 @@ fn spawn_solar_system(
                         Bloom::default(),
                     ));
 
-                    camera.with_children(|camera| {
-                        camera.spawn((
-                            Spaceship,
-                            SceneRoot(
-                                asset_server.load("models/low_poly_spaceship/scene.gltf#Scene0"),
-                            ),
-                            Transform::from_rotation(Quat::from_rotation_y(std::f32::consts::PI)),
-                        ));
-                    });
+                    camera.with_child((
+                        Spaceship,
+                        SceneRoot(asset_server.load("models/low_poly_spaceship/scene.gltf#Scene0")),
+                        Transform::from_rotation(Quat::from_rotation_y(std::f32::consts::PI)),
+                    ));
                 });
             });
         });

--- a/examples/split_screen.rs
+++ b/examples/split_screen.rs
@@ -55,10 +55,8 @@ fn setup(
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     commands.spawn((
-        DirectionalLightBundle {
-            transform: Transform::default().looking_to(Vec3::NEG_ONE, Vec3::Y),
-            ..default()
-        },
+        DirectionalLight::default(),
+        Transform::default().looking_to(Vec3::NEG_ONE, Vec3::Y),
         RenderLayers::from_layers(&[1, 2]),
     ));
 
@@ -66,11 +64,9 @@ fn setup(
     commands.spawn_big_space(ReferenceFrame::<i32>::default(), |root_frame| {
         root_frame
             .spawn_spatial((
-                Camera3dBundle {
-                    transform: Transform::from_xyz(1_000_000.0 - 10.0, 100_005.0, 0.0)
-                        .looking_to(Vec3::NEG_X, Vec3::Y),
-                    ..default()
-                },
+                Camera3d::default(),
+                Transform::from_xyz(1_000_000.0 - 10.0, 100_005.0, 0.0)
+                    .looking_to(Vec3::NEG_X, Vec3::Y),
                 CameraController::default().with_smoothness(0.8, 0.8),
                 RenderLayers::layer(2),
                 LeftCamera,
@@ -78,56 +74,42 @@ fn setup(
             ))
             .with_children(|child_builder| {
                 child_builder.spawn((
-                    PbrBundle {
-                        mesh: meshes.add(Cuboid::new(1.0, 2.0, 1.0)),
-                        material: materials.add(StandardMaterial {
-                            base_color: Color::Srgba(palettes::css::YELLOW),
-                            ..default()
-                        }),
+                    Mesh3d(meshes.add(Cuboid::new(1.0, 2.0, 1.0))),
+                    MeshMaterial3d(materials.add(StandardMaterial {
+                        base_color: Color::Srgba(palettes::css::YELLOW),
                         ..default()
-                    },
+                    })),
                     RenderLayers::layer(2),
                 ));
             });
 
         root_frame.spawn_spatial((
             RightCameraReplicated,
-            PbrBundle {
-                mesh: meshes.add(Cuboid::new(1.0, 2.0, 1.0)),
-                material: materials.add(StandardMaterial {
-                    base_color: Color::Srgba(palettes::css::FUCHSIA),
-                    ..default()
-                }),
+            Mesh3d(meshes.add(Cuboid::new(1.0, 2.0, 1.0))),
+            MeshMaterial3d(materials.add(StandardMaterial {
+                base_color: Color::Srgba(palettes::css::FUCHSIA),
                 ..default()
-            },
+            })),
             RenderLayers::layer(2),
         ));
 
         root_frame.spawn_spatial((
-            PbrBundle {
-                mesh: meshes.add(Sphere::new(1.0).mesh().ico(35).unwrap()),
-                material: materials.add(StandardMaterial {
-                    base_color: Color::Srgba(palettes::css::BLUE),
-                    ..default()
-                }),
-                transform: Transform::from_xyz(1_000_000.0, 0.0, 0.0)
-                    .with_scale(Vec3::splat(100_000.0)),
+            Mesh3d(meshes.add(Sphere::new(1.0).mesh().ico(35).unwrap())),
+            MeshMaterial3d(materials.add(StandardMaterial {
+                base_color: Color::Srgba(palettes::css::BLUE),
                 ..default()
-            },
+            })),
+            Transform::from_xyz(1_000_000.0, 0.0, 0.0).with_scale(Vec3::splat(100_000.0)),
             RenderLayers::layer(2),
         ));
 
         root_frame.spawn_spatial((
-            PbrBundle {
-                mesh: meshes.add(Sphere::new(1.0).mesh().ico(35).unwrap()),
-                material: materials.add(StandardMaterial {
-                    base_color: Color::Srgba(palettes::css::GREEN),
-                    ..default()
-                }),
-                transform: Transform::from_xyz(-1_000_000.0, 0.0, 0.0)
-                    .with_scale(Vec3::splat(100_000.0)),
+            Mesh3d(meshes.add(Sphere::new(1.0).mesh().ico(35).unwrap())),
+            MeshMaterial3d(materials.add(StandardMaterial {
+                base_color: Color::Srgba(palettes::css::GREEN),
                 ..default()
-            },
+            })),
+            Transform::from_xyz(-1_000_000.0, 0.0, 0.0).with_scale(Vec3::splat(100_000.0)),
             RenderLayers::layer(2),
         ));
     });
@@ -136,14 +118,11 @@ fn setup(
     commands.spawn_big_space(ReferenceFrame::<i32>::default(), |root_frame| {
         root_frame
             .spawn_spatial((
-                Camera3dBundle {
-                    transform: Transform::from_xyz(1_000_000.0, 100_005.0, 0.0)
-                        .looking_to(Vec3::NEG_X, Vec3::Y),
-                    camera: Camera {
-                        order: 1,
-                        clear_color: ClearColorConfig::None,
-                        ..default()
-                    },
+                Camera3d::default(),
+                Transform::from_xyz(1_000_000.0, 100_005.0, 0.0).looking_to(Vec3::NEG_X, Vec3::Y),
+                Camera {
+                    order: 1,
+                    clear_color: ClearColorConfig::None,
                     ..default()
                 },
                 RenderLayers::layer(1),
@@ -152,56 +131,42 @@ fn setup(
             ))
             .with_children(|child_builder| {
                 child_builder.spawn((
-                    PbrBundle {
-                        mesh: meshes.add(Cuboid::new(1.0, 2.0, 1.0)),
-                        material: materials.add(StandardMaterial {
-                            base_color: Color::Srgba(palettes::css::PINK),
-                            ..default()
-                        }),
+                    Mesh3d(meshes.add(Cuboid::new(1.0, 2.0, 1.0))),
+                    MeshMaterial3d(materials.add(StandardMaterial {
+                        base_color: Color::Srgba(palettes::css::PINK),
                         ..default()
-                    },
+                    })),
                     RenderLayers::layer(1),
                 ));
             });
 
         root_frame.spawn_spatial((
             LeftCameraReplicated,
-            PbrBundle {
-                mesh: meshes.add(Cuboid::new(1.0, 2.0, 1.0)),
-                material: materials.add(StandardMaterial {
-                    base_color: Color::Srgba(palettes::css::YELLOW),
-                    ..default()
-                }),
+            Mesh3d(meshes.add(Cuboid::new(1.0, 2.0, 1.0))),
+            MeshMaterial3d(materials.add(StandardMaterial {
+                base_color: Color::Srgba(palettes::css::YELLOW),
                 ..default()
-            },
+            })),
             RenderLayers::layer(1),
         ));
 
         root_frame.spawn_spatial((
-            PbrBundle {
-                mesh: meshes.add(Sphere::new(1.0).mesh().ico(35).unwrap()),
-                material: materials.add(StandardMaterial {
-                    base_color: Color::Srgba(palettes::css::BLUE),
-                    ..default()
-                }),
-                transform: Transform::from_xyz(1_000_000.0, 0.0, 0.0)
-                    .with_scale(Vec3::splat(100_000.0)),
+            Mesh3d(meshes.add(Sphere::new(1.0).mesh().ico(35).unwrap())),
+            MeshMaterial3d(materials.add(StandardMaterial {
+                base_color: Color::Srgba(palettes::css::BLUE),
                 ..default()
-            },
+            })),
+            Transform::from_xyz(1_000_000.0, 0.0, 0.0).with_scale(Vec3::splat(100_000.0)),
             RenderLayers::layer(1),
         ));
 
         root_frame.spawn_spatial((
-            PbrBundle {
-                mesh: meshes.add(Sphere::new(1.0).mesh().ico(35).unwrap()),
-                material: materials.add(StandardMaterial {
-                    base_color: Color::Srgba(palettes::css::GREEN),
-                    ..default()
-                }),
-                transform: Transform::from_xyz(-1_000_000.0, 0.0, 0.0)
-                    .with_scale(Vec3::splat(100_000.0)),
+            Mesh3d(meshes.add(Sphere::new(1.0).mesh().ico(35).unwrap())),
+            MeshMaterial3d(materials.add(StandardMaterial {
+                base_color: Color::Srgba(palettes::css::GREEN),
                 ..default()
-            },
+            })),
+            Transform::from_xyz(-1_000_000.0, 0.0, 0.0).with_scale(Vec3::splat(100_000.0)),
             RenderLayers::layer(1),
         ));
     });

--- a/examples/split_screen.rs
+++ b/examples/split_screen.rs
@@ -72,16 +72,14 @@ fn setup(
                 LeftCamera,
                 FloatingOrigin,
             ))
-            .with_children(|child_builder| {
-                child_builder.spawn((
-                    Mesh3d(meshes.add(Cuboid::new(1.0, 2.0, 1.0))),
-                    MeshMaterial3d(materials.add(StandardMaterial {
-                        base_color: Color::Srgba(palettes::css::YELLOW),
-                        ..default()
-                    })),
-                    RenderLayers::layer(2),
-                ));
-            });
+            .with_child((
+                Mesh3d(meshes.add(Cuboid::new(1.0, 2.0, 1.0))),
+                MeshMaterial3d(materials.add(StandardMaterial {
+                    base_color: Color::Srgba(palettes::css::YELLOW),
+                    ..default()
+                })),
+                RenderLayers::layer(2),
+            ));
 
         root_frame.spawn_spatial((
             RightCameraReplicated,
@@ -129,16 +127,14 @@ fn setup(
                 RightCamera,
                 FloatingOrigin,
             ))
-            .with_children(|child_builder| {
-                child_builder.spawn((
-                    Mesh3d(meshes.add(Cuboid::new(1.0, 2.0, 1.0))),
-                    MeshMaterial3d(materials.add(StandardMaterial {
-                        base_color: Color::Srgba(palettes::css::PINK),
-                        ..default()
-                    })),
-                    RenderLayers::layer(1),
-                ));
-            });
+            .with_child((
+                Mesh3d(meshes.add(Cuboid::new(1.0, 2.0, 1.0))),
+                MeshMaterial3d(materials.add(StandardMaterial {
+                    base_color: Color::Srgba(palettes::css::PINK),
+                    ..default()
+                })),
+                RenderLayers::layer(1),
+            ));
 
         root_frame.spawn_spatial((
             LeftCameraReplicated,

--- a/src/bundles.rs
+++ b/src/bundles.rs
@@ -36,12 +36,6 @@ pub struct BigReferenceFrameBundle<P: GridPrecision> {
     /// The visibility of the entity.
     #[cfg(feature = "bevy_render")]
     pub visibility: bevy_render::view::Visibility,
-    /// The inherited visibility of the entity.
-    #[cfg(feature = "bevy_render")]
-    pub inherited: bevy_render::view::InheritedVisibility,
-    /// The view visibility of the entity.
-    #[cfg(feature = "bevy_render")]
-    pub view: bevy_render::view::ViewVisibility,
     /// The transform of the entity.
     pub transform: Transform,
     /// The global transform of the entity for rendering, computed relative to the floating origin.
@@ -58,12 +52,6 @@ pub struct BigSpaceRootBundle<P: GridPrecision> {
     /// The visibility of the entity.
     #[cfg(feature = "bevy_render")]
     pub visibility: bevy_render::view::Visibility,
-    /// The inherited visibility of the entity.
-    #[cfg(feature = "bevy_render")]
-    pub inherited: bevy_render::view::InheritedVisibility,
-    /// The view visibility of the entity.
-    #[cfg(feature = "bevy_render")]
-    pub view: bevy_render::view::ViewVisibility,
     /// The root reference frame
     pub reference_frame: ReferenceFrame<P>,
     /// Tracks the current floating origin

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -285,7 +285,7 @@ pub fn camera_controller<P: GridPrecision>(
 
         let (vel_t_current, vel_r_current) = (controller.vel_translation, controller.vel_rotation);
         let (vel_t_target, vel_r_target) =
-            input.target_velocity(&controller, speed, time.delta_seconds_f64());
+            input.target_velocity(&controller, speed, time.delta_secs_f64());
 
         let cam_rot = position.transform.rotation.as_dquat();
         let vel_t_next = cam_rot * vel_t_target; // Orients the translation to match the camera

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -160,6 +160,13 @@ impl<'a, P: GridPrecision> ReferenceFrameCommands<'a, P> {
             .with_children(|child_builder| spawn_children(child_builder));
         self
     }
+
+    /// Spawns the passed bundle which provides this reference frame,
+    /// and adds it to this entity as a child.
+    pub fn with_child<B: Bundle>(&mut self, bundle: B) -> &mut Self {
+        self.commands.entity(self.entity).with_child(bundle);
+        self
+    }
 }
 
 /// Insert the reference frame on drop.
@@ -190,6 +197,12 @@ impl<'a, P: GridPrecision> SpatialEntityCommands<'a, P> {
         self.commands
             .entity(self.entity)
             .with_children(|child_builder| spawn_children(child_builder));
+        self
+    }
+
+    /// Spawns the passed bundle and adds it to this entity as a child.
+    pub fn with_child<B: Bundle>(&mut self, bundle: B) -> &mut Self {
+        self.commands.entity(self.entity).with_child(bundle);
         self
     }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -70,12 +70,7 @@ impl<'a, P: GridPrecision> ReferenceFrameCommands<'a, P> {
             .spawn((
                 #[cfg(feature = "bevy_render")]
                 bevy_render::view::Visibility::default(),
-                #[cfg(feature = "bevy_render")]
-                bevy_render::view::InheritedVisibility::default(),
-                #[cfg(feature = "bevy_render")]
-                bevy_render::view::ViewVisibility::default(),
                 Transform::default(),
-                GlobalTransform::default(),
                 GridCell::<P>::default(),
             ))
             .insert(bundle)
@@ -136,12 +131,7 @@ impl<'a, P: GridPrecision> ReferenceFrameCommands<'a, P> {
             .spawn((
                 #[cfg(feature = "bevy_render")]
                 bevy_render::view::Visibility::default(),
-                #[cfg(feature = "bevy_render")]
-                bevy_render::view::InheritedVisibility::default(),
-                #[cfg(feature = "bevy_render")]
-                bevy_render::view::ViewVisibility::default(),
                 Transform::default(),
-                GlobalTransform::default(),
                 GridCell::<P>::default(),
                 ReferenceFrame::<P>::default(),
             ))

--- a/src/floating_origins.rs
+++ b/src/floating_origins.rs
@@ -29,6 +29,8 @@ pub struct FloatingOrigin;
 /// that `BigSpace`.
 #[derive(Debug, Default, Component, Reflect)]
 #[reflect(Component)]
+// We do not require ReferenceFrame, because we want more control over when the reference frame is
+// inserted, especially with the command extension.
 pub struct BigSpace {
     /// Set the entity to use as the floating origin within this high precision hierarchy.
     pub floating_origin: Option<Entity>,

--- a/src/grid_cell.rs
+++ b/src/grid_cell.rs
@@ -17,6 +17,7 @@ use self::{precision::GridPrecision, reference_frame::ReferenceFrame};
 /// that cell.
 #[derive(Component, Default, Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, Reflect)]
 #[reflect(Component, Default, PartialEq)]
+#[require(Transform, GlobalTransform)]
 pub struct GridCell<P: GridPrecision> {
     /// The x-index of the cell.
     pub x: P,

--- a/src/precision.rs
+++ b/src/precision.rs
@@ -2,7 +2,7 @@
 
 use std::{hash::Hash, ops::Add};
 
-use bevy_reflect::Reflect;
+use bevy_reflect::{Reflect, Typed};
 
 /// Used to make the floating origin plugin generic over many grid sizes.
 ///
@@ -50,6 +50,7 @@ pub trait GridPrecision:
     + Send
     + Sync
     + Reflect
+    + Typed
     + Add
     + std::fmt::Debug
     + std::fmt::Display

--- a/src/reference_frame/local_origin.rs
+++ b/src/reference_frame/local_origin.rs
@@ -634,7 +634,7 @@ mod tests {
             ))
             .id();
 
-        app.world_mut().entity_mut(root).add_children(&[child]);
+        app.world_mut().entity_mut(root).add_child(child);
 
         let mut state = SystemState::<ReferenceFramesMut<i64>>::new(app.world_mut());
         let mut reference_frames = state.get_mut(app.world_mut());
@@ -698,7 +698,7 @@ mod tests {
             ))
             .id();
 
-        app.world_mut().entity_mut(root).add_children(&[child]);
+        app.world_mut().entity_mut(root).add_child(child);
 
         let mut state = SystemState::<ReferenceFramesMut<i32>>::new(app.world_mut());
         let mut reference_frames = state.get_mut(app.world_mut());

--- a/src/reference_frame/local_origin.rs
+++ b/src/reference_frame/local_origin.rs
@@ -511,10 +511,10 @@ mod tests {
         let parent = app.world_mut().spawn(frame_bundle.clone()).id();
         let root = app.world_mut().spawn(frame_bundle.clone()).id();
 
-        app.world_mut().entity_mut(root).push_children(&[parent]);
+        app.world_mut().entity_mut(root).add_child(parent);
         app.world_mut()
             .entity_mut(parent)
-            .push_children(&[child_1, child_2]);
+            .add_children(&[child_1, child_2]);
 
         let mut state = SystemState::<ReferenceFramesMut<i32>>::new(app.world_mut());
         let mut ref_frames = state.get_mut(app.world_mut());
@@ -573,7 +573,7 @@ mod tests {
             ))
             .id();
 
-        app.world_mut().entity_mut(root).push_children(&[child]);
+        app.world_mut().entity_mut(root).add_child(child);
 
         let mut state = SystemState::<ReferenceFramesMut<i32>>::new(app.world_mut());
         let mut reference_frames = state.get_mut(app.world_mut());
@@ -634,7 +634,7 @@ mod tests {
             ))
             .id();
 
-        app.world_mut().entity_mut(root).push_children(&[child]);
+        app.world_mut().entity_mut(root).add_children(&[child]);
 
         let mut state = SystemState::<ReferenceFramesMut<i64>>::new(app.world_mut());
         let mut reference_frames = state.get_mut(app.world_mut());
@@ -698,7 +698,7 @@ mod tests {
             ))
             .id();
 
-        app.world_mut().entity_mut(root).push_children(&[child]);
+        app.world_mut().entity_mut(root).add_children(&[child]);
 
         let mut state = SystemState::<ReferenceFramesMut<i32>>::new(app.world_mut());
         let mut reference_frames = state.get_mut(app.world_mut());

--- a/src/reference_frame/mod.rs
+++ b/src/reference_frame/mod.rs
@@ -35,6 +35,8 @@ pub mod propagation;
 /// worse, around the center of the galaxy.
 #[derive(Debug, Clone, Reflect, Component)]
 #[reflect(Component)]
+// We do not require the Transform, GlobalTransform, or GridCell, because these are not required in
+// all cases: e.g. BigSpace should not have a Transform or GridCell.
 pub struct ReferenceFrame<P: GridPrecision + Reflect> {
     /// The high-precision position of the floating origin's current grid cell local to this
     /// reference frame.

--- a/src/reference_frame/propagation.rs
+++ b/src/reference_frame/propagation.rs
@@ -102,10 +102,10 @@ impl<P: GridPrecision> ReferenceFrame<P> {
     ///
     /// # Safety
     ///
-    /// - While this function is running, `transform_query` must not have any fetches for `entity`, nor
-    ///   any of its descendants.
-    /// - The caller must ensure that the hierarchy leading to `entity` is well-formed and must remain
-    ///   as a tree or a forest. Each entity must have at most one parent.
+    /// - While this function is running, `transform_query` must not have any fetches for `entity`,
+    ///   nor any of its descendants.
+    /// - The caller must ensure that the hierarchy leading to `entity` is well-formed and must
+    ///   remain as a tree or a forest. Each entity must have at most one parent.
     unsafe fn propagate_recursive(
         parent: &GlobalTransform,
         transform_query: &Query<

--- a/src/reference_frame/propagation.rs
+++ b/src/reference_frame/propagation.rs
@@ -103,9 +103,9 @@ impl<P: GridPrecision> ReferenceFrame<P> {
     /// # Safety
     ///
     /// - While this function is running, `transform_query` must not have any fetches for `entity`, nor
-    /// any of its descendants.
+    ///   any of its descendants.
     /// - The caller must ensure that the hierarchy leading to `entity` is well-formed and must remain
-    /// as a tree or a forest. Each entity must have at most one parent.
+    ///   as a tree or a forest. Each entity must have at most one parent.
     unsafe fn propagate_recursive(
         parent: &GlobalTransform,
         transform_query: &Query<

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -10,9 +10,7 @@ fn changing_floating_origin_updates_global_transform() {
     let first = app
         .world_mut()
         .spawn((
-            TransformBundle::from_transform(Transform::from_translation(Vec3::new(
-                150.0, 0.0, 0.0,
-            ))),
+            Transform::from_translation(Vec3::new(150.0, 0.0, 0.0)),
             GridCell::<i32>::new(5, 0, 0),
             FloatingOrigin,
         ))
@@ -21,16 +19,14 @@ fn changing_floating_origin_updates_global_transform() {
     let second = app
         .world_mut()
         .spawn((
-            TransformBundle::from_transform(Transform::from_translation(Vec3::new(
-                0.0, 0.0, 300.0,
-            ))),
+            Transform::from_translation(Vec3::new(0.0, 0.0, 300.0)),
             GridCell::<i32>::new(0, -15, 0),
         ))
         .id();
 
     app.world_mut()
         .spawn(BigSpaceRootBundle::<i32>::default())
-        .push_children(&[first, second]);
+        .add_children(&[first, second]);
 
     app.update();
 
@@ -55,9 +51,7 @@ fn child_global_transforms_are_updated_when_floating_origin_changes() {
     let first = app
         .world_mut()
         .spawn((
-            TransformBundle::from_transform(Transform::from_translation(Vec3::new(
-                150.0, 0.0, 0.0,
-            ))),
+            Transform::from_translation(Vec3::new(150.0, 0.0, 0.0)),
             GridCell::<i32>::new(5, 0, 0),
             FloatingOrigin,
         ))
@@ -66,21 +60,15 @@ fn child_global_transforms_are_updated_when_floating_origin_changes() {
     let second = app
         .world_mut()
         .spawn((
-            TransformBundle::from_transform(Transform::from_translation(Vec3::new(
-                0.0, 0.0, 300.0,
-            ))),
+            Transform::from_translation(Vec3::new(0.0, 0.0, 300.0)),
             GridCell::<i32>::new(0, -15, 0),
         ))
-        .with_children(|parent| {
-            parent.spawn((TransformBundle::from_transform(
-                Transform::from_translation(Vec3::new(0.0, 0.0, 300.0)),
-            ),));
-        })
+        .with_child(Transform::from_translation(Vec3::new(0.0, 0.0, 300.0)))
         .id();
 
     app.world_mut()
         .spawn(BigSpaceRootBundle::<i32>::default())
-        .push_children(&[first, second]);
+        .add_children(&[first, second]);
 
     app.update();
 

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -89,7 +89,7 @@ pub fn validate_hierarchy<V: 'static + ValidHierarchyNode + Default>(world: &mut
                         });
 
                     let mut inspect = String::new();
-                    world.inspect_entity(*entity).iter().for_each(|info| {
+                    world.inspect_entity(*entity).for_each(|info| {
                         inspect.push('\t');
                         inspect.push('\t');
                         inspect.push_str(info.name());
@@ -130,7 +130,7 @@ pub(super) mod sealed {
         fn clone_box(&self) -> Box<dyn ValidHierarchyNode>;
     }
 
-    impl<T: ?Sized> CloneHierarchy for T
+    impl<T> CloneHierarchy for T
     where
         T: 'static + ValidHierarchyNode + Clone,
     {


### PR DESCRIPTION
Migrate to the Bevy 0.15 RC.

- Migrate examples
- Add `with_child` to `ReferenceFrameCommands` and `SpatialEntityCommands` to match Bevy's `EntityCommands::with_child`
- Add `Typed` bound to `GridPrecision` (required for `register_type`)