### PR TITLE
Partition Bounds

### DIFF
--- a/examples/spatial_hash.rs
+++ b/examples/spatial_hash.rs
@@ -36,13 +36,7 @@ fn main() {
                 draw_partitions.after(GridHashMapSystem::UpdatePartition),
             ),
         )
-        .add_systems(
-            Update,
-            (
-                cursor_grab,
-                spawn_spheres.run_if(input_pressed(KeyCode::KeyR)),
-            ),
-        )
+        .add_systems(Update, (cursor_grab, spawn_spheres))
         .init_resource::<MaterialPresets>()
         .run();
 }
@@ -288,12 +282,19 @@ fn spawn(mut commands: Commands) {
 
 fn spawn_spheres(
     mut commands: Commands,
+    input: Res<ButtonInput<KeyCode>>,
     material_presets: Res<MaterialPresets>,
     mut grid: Query<(Entity, &Grid<i32>, &mut Children)>,
     non_players: Query<(), With<NonPlayer>>,
 ) {
     let n_entities = non_players.iter().len() as f32;
-    let n_spawn = 10 * (1.0 + n_entities / 1e3) as usize;
+    let n_spawn = if input.pressed(KeyCode::KeyR) {
+        10 * (1.0 + n_entities / 1e1) as usize
+    } else if input.pressed(KeyCode::KeyU) {
+        1_000
+    } else {
+        return;
+    };
 
     let (entity, _grid, mut children) = grid.single_mut();
     let mut dyn_parent = bevy_reflect::DynamicTupleStruct::default();

--- a/examples/spatial_hash.rs
+++ b/examples/spatial_hash.rs
@@ -5,9 +5,19 @@ use bevy::{
     prelude::*,
 };
 use bevy_ecs::entity::EntityHasher;
+use bevy_input::common_conditions::input_pressed;
 use bevy_math::DVec3;
 use big_space::prelude::*;
-use noise::{NoiseFn, Perlin};
+use noise::{NoiseFn, Simplex};
+use smallvec::SmallVec;
+use turborand::prelude::*;
+
+// Try bumping this up to really stress test. I'm able to push a million entities with an M3 Max.
+const HALF_WIDTH: f32 = 500.0;
+const CELL_WIDTH: f32 = 10.0;
+// How fast the entities should move, causing them to move into neighboring cells.
+const MOVEMENT_SPEED: f32 = 5.0;
+const PERCENT_STATIC: f32 = 1.0;
 
 fn main() {
     App::new()
@@ -26,18 +36,16 @@ fn main() {
                 draw_partitions.after(GridHashMapSystem::UpdatePartition),
             ),
         )
-        .add_systems(Update, cursor_grab)
+        .add_systems(
+            Update,
+            (
+                cursor_grab,
+                spawn_spheres.run_if(input_pressed(KeyCode::KeyR)),
+            ),
+        )
         .init_resource::<MaterialPresets>()
         .run();
 }
-
-// Try bumping this up to really stress test. I'm able to push a million entities with an M3 Max.
-const N_ENTITIES: usize = 100_000;
-const HALF_WIDTH: f32 = 40.0;
-const CELL_WIDTH: f32 = 10.0;
-// How fast the entities should move, causing them to move into neighboring cells.
-const MOVEMENT_SPEED: f32 = 5.0;
-const PERCENT_STATIC: f32 = 0.9;
 
 #[derive(Component)]
 struct Player;
@@ -50,25 +58,35 @@ struct MaterialPresets {
     default: Handle<StandardMaterial>,
     highlight: Handle<StandardMaterial>,
     flood: Handle<StandardMaterial>,
+    sphere: Handle<Mesh>,
 }
 
 impl FromWorld for MaterialPresets {
     fn from_world(world: &mut World) -> Self {
         let mut materials = world.resource_mut::<Assets<StandardMaterial>>();
 
-        let d: StandardMaterial = StandardMaterial {
+        let default = materials.add(StandardMaterial {
             base_color: Color::from(Srgba::new(0.5, 0.5, 0.5, 1.0)),
             perceptual_roughness: 0.2,
             metallic: 0.0,
             ..Default::default()
-        };
-        let h: StandardMaterial = Color::from(Srgba::new(2.0, 0.0, 8.0, 1.0)).into();
-        let f: StandardMaterial = Color::from(Srgba::new(1.1, 0.1, 1.0, 1.0)).into();
+        });
+        let highlight = materials.add(Color::from(Srgba::new(2.0, 0.0, 8.0, 1.0)));
+        let flood = materials.add(Color::from(Srgba::new(1.1, 0.1, 1.0, 1.0)));
+
+        let mut meshes = world.resource_mut::<Assets<Mesh>>();
+        let sphere = meshes.add(
+            Sphere::new(HALF_WIDTH / (1_000_000_f32).powf(0.33) * 0.5)
+                .mesh()
+                .ico(0)
+                .unwrap(),
+        );
 
         Self {
-            default: materials.add(d),
-            highlight: materials.add(h),
-            flood: materials.add(f),
+            default,
+            highlight,
+            flood,
+            sphere,
         }
     }
 }
@@ -79,7 +97,7 @@ fn draw_partitions(
     grids: Query<(&GlobalTransform, &Grid<i32>)>,
     camera: Query<&GridHash<i32>, With<Camera>>,
 ) {
-    for (id, p) in partitions.iter() {
+    for (id, p) in partitions.iter().take(10_000) {
         let Ok((transform, grid)) = grids.get(p.grid()) else {
             return;
         };
@@ -92,35 +110,19 @@ fn draw_partitions(
 
         p.iter()
             .filter(|hash| *hash != camera.single())
+            .take(1_000)
             .for_each(|h| {
                 let center = [h.cell().x, h.cell().y, h.cell().z];
                 let local_trans = Transform::from_translation(IVec3::from(center).as_vec3() * l)
                     .with_scale(Vec3::splat(l));
                 gizmos.cuboid(
                     transform.mul_transform(local_trans),
-                    Hsla::new(hue, 1.0, 0.5, 0.2),
+                    Hsla::new(hue, 1.0, 0.5, 0.8),
                 );
             });
 
-        let Some(min) = p
-            .iter()
-            .filter(|hash| *hash != camera.single())
-            .map(|h| [h.cell().x, h.cell().y, h.cell().z])
-            .reduce(|[ax, ay, az], [ix, iy, iz]| [ax.min(ix), ay.min(iy), az.min(iz)])
-            .map(|v| IVec3::from(v).as_vec3() * l)
-        else {
-            continue;
-        };
-
-        let Some(max) = p
-            .iter()
-            .filter(|hash| *hash != camera.single())
-            .map(|h| [h.cell().x, h.cell().y, h.cell().z])
-            .reduce(|[ax, ay, az], [ix, iy, iz]| [ax.max(ix), ay.max(iy), az.max(iz)])
-            .map(|v| IVec3::from(v).as_vec3() * l)
-        else {
-            continue;
-        };
+        let min = IVec3::from([p.min().x, p.min().y, p.min().z]).as_vec3() * l;
+        let max = IVec3::from([p.max().x, p.max().y, p.max().z]).as_vec3() * l;
 
         let size = max - min;
         let center = min + (size) * 0.5;
@@ -128,7 +130,7 @@ fn draw_partitions(
 
         gizmos.cuboid(
             transform.mul_transform(local_trans),
-            Hsla::new(hue, 1.0, 0.5, 0.2),
+            Hsla::new(hue, 1.0, 0.5, 0.8),
         );
     }
 }
@@ -152,6 +154,7 @@ fn move_player(
     hash_stats: Res<big_space::timing::SmoothedStat<big_space::timing::GridHashStats>>,
     prop_stats: Res<big_space::timing::SmoothedStat<big_space::timing::PropagationStats>>,
 ) {
+    let n_entities = non_player.iter().len();
     for neighbor in neighbors.iter() {
         if let Ok(mut material) = materials.get_mut(*neighbor) {
             **material = material_presets.default.clone_weak();
@@ -163,10 +166,12 @@ fn move_player(
     if scale.abs() > 0.0 {
         // Avoid change detection
         for (i, (mut transform, _, _)) in non_player.iter_mut().enumerate() {
-            if i > (PERCENT_STATIC * N_ENTITIES as f32) as usize {
+            if i < ((1.0 - PERCENT_STATIC) * n_entities as f32) as usize {
                 transform.translation.x += t.sin() * scale;
                 transform.translation.y += t.cos() * scale;
                 transform.translation.z += (t * 2.3).sin() * scale;
+            } else {
+                break;
             }
         }
     }
@@ -229,7 +234,15 @@ Update Maps: {: >16.1?}
 Update Partitions: {: >10.1?}
 
 Total: {: >22.1?}",
-        N_ENTITIES,
+        n_entities
+            .to_string()
+            .as_bytes()
+            .rchunks(3)
+            .rev()
+            .map(std::str::from_utf8)
+            .collect::<Result<Vec<&str>, _>>()
+            .unwrap()
+            .join(","),
         //
         prop_stats.avg().grid_recentering(),
         prop_stats.avg().low_precision_root_tagging(),
@@ -246,36 +259,7 @@ Total: {: >22.1?}",
     );
 }
 
-fn spawn(
-    mut commands: Commands,
-    mut materials: ResMut<Assets<StandardMaterial>>,
-    mut meshes: ResMut<Assets<Mesh>>,
-    material_presets: Res<MaterialPresets>,
-) {
-    use turborand::prelude::*;
-    let rng = Rng::with_seed(342525);
-    let noise = Perlin::new(345612);
-
-    let rng = || loop {
-        let noise_scale = 5.0;
-        let threshold = 0.70;
-        let rng_val = || rng.f64_normalized() * noise_scale;
-        let coord = [rng_val(), rng_val(), rng_val()];
-        if noise.get(coord) > threshold {
-            return DVec3::from_array(coord).as_vec3() * HALF_WIDTH * CELL_WIDTH
-                / noise_scale as f32;
-        }
-    };
-
-    let values: Vec<_> = std::iter::repeat_with(rng).take(N_ENTITIES).collect();
-
-    let sphere_mesh_lq = meshes.add(
-        Sphere::new(HALF_WIDTH / (N_ENTITIES as f32).powf(0.33) * 0.2)
-            .mesh()
-            .ico(0)
-            .unwrap(),
-    );
-
+fn spawn(mut commands: Commands) {
     commands.spawn_big_space::<i32>(Grid::new(CELL_WIDTH, 0.0), |root| {
         root.spawn_spatial((
             FloatingOrigin,
@@ -298,32 +282,77 @@ fn spawn(
             b.spawn(DirectionalLight::default());
         });
 
-        for (i, value) in values.iter().enumerate() {
-            let mut sphere_builder = root.spawn((BigSpatialBundle::<i32> {
-                transform: Transform::from_xyz(value.x, value.y, value.z),
-                ..default()
-            },));
-            if i == 0 {
-                sphere_builder.insert((
-                    Player,
-                    Mesh3d(meshes.add(Sphere::new(1.0))),
-                    MeshMaterial3d(materials.add(Color::from(Srgba::new(20.0, 20.0, 0.0, 1.0)))),
-                    Transform::from_scale(Vec3::splat(2.0)),
-                ));
-            } else {
-                sphere_builder.insert((
-                    NonPlayer,
-                    Mesh3d(sphere_mesh_lq.clone()),
-                    MeshMaterial3d(material_presets.default.clone_weak()),
-                    bevy_render::view::VisibilityRange {
-                        start_margin: 1.0..5.0,
-                        end_margin: HALF_WIDTH * CELL_WIDTH * 0.5..HALF_WIDTH * CELL_WIDTH * 0.8,
-                        use_aabb: false,
-                    },
-                ));
-            }
-        }
+        root.spawn_spatial(Player);
     });
+}
+
+fn spawn_spheres(
+    mut commands: Commands,
+    material_presets: Res<MaterialPresets>,
+    mut grid: Query<(Entity, &Grid<i32>, &mut Children)>,
+    non_players: Query<(), With<NonPlayer>>,
+) {
+    let n_entities = non_players.iter().len() as f32;
+    let n_spawn = 10 * (1.0 + n_entities / 1e3) as usize;
+
+    let (entity, _grid, mut children) = grid.single_mut();
+    let mut dyn_parent = bevy_reflect::DynamicTupleStruct::default();
+    dyn_parent.insert(entity);
+    let dyn_parent = dyn_parent.as_partial_reflect();
+
+    let new_children = sample_noise(n_spawn, &Simplex::new(345612), &Rng::new())
+        .map(|value| {
+            let hash = GridHash::<i32>::__new_manual(entity, &GridCell::default());
+            commands
+                .spawn((
+                    Transform::from_xyz(value.x, value.y, value.z),
+                    GlobalTransform::default(),
+                    GridCell::<i32>::default(),
+                    FastGridHash::from(hash),
+                    hash,
+                    NonPlayer,
+                    Parent::from_reflect(dyn_parent).unwrap(),
+                    // Mesh3d(material_presets.sphere.clone_weak()),
+                    // MeshMaterial3d(material_presets.default.clone_weak()),
+                    // bevy_render::view::VisibilityRange {
+                    //     start_margin: 1.0..5.0,
+                    //     end_margin: HALF_WIDTH * CELL_WIDTH * 0.5..HALF_WIDTH * CELL_WIDTH * 0.8,
+                    //     use_aabb: false,
+                    // },
+                    // bevy_render::view::NoFrustumCulling,
+                ))
+                .id()
+        })
+        .chain(children.iter().copied())
+        .collect::<SmallVec<[Entity; 8]>>();
+
+    let mut dyn_children = bevy_reflect::DynamicTupleStruct::default();
+    dyn_children.insert(new_children);
+    let dyn_children = dyn_children.as_partial_reflect();
+
+    *children = Children::from_reflect(dyn_children).unwrap();
+}
+
+#[inline]
+fn sample_noise<'a, T: NoiseFn<f64, 3>>(
+    n_entities: usize,
+    noise: &'a T,
+    rng: &'a Rng,
+) -> impl Iterator<Item = Vec3> + use<'a, T> {
+    std::iter::repeat_with(
+        || loop {
+            let noise_scale = 2.0;
+            let threshold = 0.50;
+            let rng_val = || rng.f64_normalized() * noise_scale;
+            let coord = [rng_val(), rng_val(), rng_val()];
+            if noise.get(coord) > threshold {
+                return DVec3::from_array(coord).as_vec3() * HALF_WIDTH * CELL_WIDTH
+                    / noise_scale as f32;
+            }
+        },
+        //  Vec3::ONE
+    )
+    .take(n_entities)
 }
 
 fn setup_ui(mut commands: Commands, asset_server: Res<AssetServer>) {

--- a/src/grid/cell.rs
+++ b/src/grid/cell.rs
@@ -36,7 +36,7 @@ pub struct GridCellAny;
 ///
 /// [`BigSpace`]s are only allowed to have a single type of `GridCell`, you cannot mix
 /// [`GridPrecision`]s.
-#[derive(Component, Default, Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, Reflect)]
+#[derive(Component, Default, Debug, PartialEq, Eq, Clone, Copy, Hash, Reflect)]
 #[reflect(Component, Default, PartialEq)]
 #[require(Transform, GlobalTransform)]
 #[component(storage = "Table", on_add = Self::on_add, on_remove = Self::on_remove)]
@@ -84,6 +84,28 @@ impl<P: GridPrecision> GridCell<P> {
             x: self.x.as_f64() * grid.cell_edge_length() as f64,
             y: self.y.as_f64() * grid.cell_edge_length() as f64,
             z: self.z.as_f64() * grid.cell_edge_length() as f64,
+        }
+    }
+
+    /// Returns a cell containing the minimum values for each element of self and rhs.
+    ///
+    /// In other words this computes [self.x.min(rhs.x), self.y.min(rhs.y), ..].
+    pub fn min(&self, rhs: Self) -> Self {
+        Self {
+            x: self.x.min(rhs.x),
+            y: self.y.min(rhs.y),
+            z: self.z.min(rhs.z),
+        }
+    }
+
+    /// Returns a cell containing the maximum values for each element of self and rhs.
+    ///
+    /// In other words this computes [self.x.max(rhs.x), self.y.max(rhs.y), ..].
+    pub fn max(&self, rhs: Self) -> Self {
+        Self {
+            x: self.x.max(rhs.x),
+            y: self.y.max(rhs.y),
+            z: self.z.max(rhs.z),
         }
     }
 

--- a/src/hash/mod.rs
+++ b/src/hash/mod.rs
@@ -92,14 +92,14 @@ impl<T: QueryFilter + Send + Sync + 'static> GridHashMapFilter for T {}
 /// react to a component being mutated. For now, this performs well enough.
 #[derive(Resource)]
 struct ChangedGridHashes<P: GridPrecision, F: GridHashMapFilter> {
-    list: Vec<Entity>,
+    updated: Vec<Entity>,
     spooky: PhantomData<(P, F)>,
 }
 
 impl<P: GridPrecision, F: GridHashMapFilter> Default for ChangedGridHashes<P, F> {
     fn default() -> Self {
         Self {
-            list: Vec::new(),
+            updated: Vec::new(),
             spooky: PhantomData,
         }
     }

--- a/src/hash/partition.rs
+++ b/src/hash/partition.rs
@@ -63,7 +63,7 @@ impl Hash for GridPartitionId {
     }
 }
 
-/// Groups connected [`GridCell`](crate::GridCell)s into [`GridPartition`]s.
+/// Groups connected [`GridCell`]s into [`GridPartition`]s.
 ///
 /// Partitions divide space into independent groups of cells.
 ///


### PR DESCRIPTION
Compute partition bounds during updates, to avoid needing to iterate over all cells in a partition every time this information is needed.