### PR TITLE
0.16 (passing tests, benches and examples unported)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,10 @@ documentation = "https://docs.rs/crate/big_space/latest"
 
 [features]
 default = []
-all = ["debug", "camera"] # Can't use all-features, integer type features are incompatible.
+all = [
+    "debug",
+    "camera",
+] # Can't use all-features, integer type features are incompatible.
 debug = ["bevy_gizmos", "bevy_color"]
 camera = ["bevy_render", "bevy_time", "bevy_input"]
 i8 = []
@@ -22,27 +25,48 @@ i128 = []
 [dependencies]
 tracing = "0.1" # Less deps than pulling in bevy_log
 smallvec = "1.13.2" # Already used by bevy in commands
-bevy_app = { version = "0.15.0", default-features = false }
-bevy_ecs = { version = "0.15.0", default-features = true }
-bevy_hierarchy = { version = "0.15.0", default-features = false }
-bevy_math = { version = "0.15.0", default-features = false }
-bevy_reflect = { version = "0.15.0", default-features = false }
-bevy_tasks = { version = "0.15.0", default-features = false }
-bevy_transform = { version = "0.15.0", default-features = false, features = [
-    "bevy-support",
+bevy_app = { path = "../bevy/crates/bevy_app", default-features = false, features = [
+    "std",
 ] }
-bevy_utils = { version = "0.15.0", default-features = false }
+bevy_ecs = { path = "../bevy/crates/bevy_ecs", default-features = true, features = [
+    "std",
+] }
+bevy_math = { path = "../bevy/crates/bevy_math", default-features = false, features = [
+    "std",
+] }
+bevy_reflect = { path = "../bevy/crates/bevy_reflect", default-features = false, features = [
+    "std",
+] }
+bevy_tasks = { path = "../bevy/crates/bevy_tasks", default-features = false, features = [
+    "std",
+] }
+bevy_transform = { path = "../bevy/crates/bevy_transform", default-features = false, features = [
+    "bevy-support",
+    "std",
+    "bevy_reflect",
+    "async_executor",
+] }
+bevy_utils = { path = "../bevy/crates/bevy_utils", default-features = false, features = [
+    "std",
+] }
+bevy_platform_support = { path = "../bevy/crates/bevy_platform_support", default-features = false, features = [
+    "std",
+] }
 # Optional
-bevy_color = { version = "0.15.0", default-features = false, optional = true }
-bevy_gizmos = { version = "0.15.0", default-features = false, optional = true }
-bevy_render = { version = "0.15.0", default-features = false, optional = true }
-bevy_input = { version = "0.15.0", default-features = false, optional = true }
-bevy_time = { version = "0.15.0", default-features = false, optional = true }
+bevy_color = { path = "../bevy/crates/bevy_color", default-features = false, optional = true, features = [
+    "std",
+] }
+bevy_gizmos = { path = "../bevy/crates/bevy_gizmos", default-features = false, optional = true }
+bevy_render = { path = "../bevy/crates/bevy_render", default-features = false, optional = true }
+bevy_input = { path = "../bevy/crates/bevy_input", default-features = false, optional = true }
+bevy_time = { path = "../bevy/crates/bevy_time", default-features = false, optional = true, features = [
+    "std",
+] }
 
 
 [dev-dependencies]
 big_space = { path = "", features = ["debug", "camera"] }
-bevy = { version = "0.15.0", default-features = false, features = [
+bevy = { path = "../bevy", default-features = false, features = [
     "bevy_scene",
     "bevy_asset",
     "bevy_gltf",
@@ -61,7 +85,7 @@ noise = "0.9"
 turborand = "0.10"
 criterion = "0.5"
 bytemuck = "1.20"
-bevy_hanabi = "0.14"
+# bevy_hanabi = "0.14"
 
 [[bench]]
 name = "benchmarks"
@@ -100,10 +124,10 @@ name = "minimal"
 path = "examples/minimal.rs"
 doc-scrape-examples = false
 
-[[example]]
-name = "particles"
-path = "examples/particles.rs"
-doc-scrape-examples = false
+# [[example]]
+# name = "particles"
+# path = "examples/particles.rs"
+# doc-scrape-examples = false
 
 [[example]]
 name = "planets"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,48 +25,48 @@ i128 = []
 [dependencies]
 tracing = "0.1" # Less deps than pulling in bevy_log
 smallvec = "1.13.2" # Already used by bevy in commands
-bevy_app = { path = "../bevy/crates/bevy_app", default-features = false, features = [
+bevy_app = { git = "https://github.com/bevyengine/bevy.git", default-features = false, features = [
     "std",
 ] }
-bevy_ecs = { path = "../bevy/crates/bevy_ecs", default-features = true, features = [
+bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", default-features = true, features = [
     "std",
 ] }
-bevy_math = { path = "../bevy/crates/bevy_math", default-features = false, features = [
+bevy_math = { git = "https://github.com/bevyengine/bevy.git", default-features = false, features = [
     "std",
 ] }
-bevy_reflect = { path = "../bevy/crates/bevy_reflect", default-features = false, features = [
+bevy_reflect = { git = "https://github.com/bevyengine/bevy.git", default-features = false, features = [
     "std",
 ] }
-bevy_tasks = { path = "../bevy/crates/bevy_tasks", default-features = false, features = [
+bevy_tasks = { git = "https://github.com/bevyengine/bevy.git", default-features = false, features = [
     "std",
 ] }
-bevy_transform = { path = "../bevy/crates/bevy_transform", default-features = false, features = [
+bevy_transform = { git = "https://github.com/bevyengine/bevy.git", default-features = false, features = [
     "bevy-support",
     "std",
     "bevy_reflect",
     "async_executor",
 ] }
-bevy_utils = { path = "../bevy/crates/bevy_utils", default-features = false, features = [
+bevy_utils = { git = "https://github.com/bevyengine/bevy.git", default-features = false, features = [
     "std",
 ] }
-bevy_platform_support = { path = "../bevy/crates/bevy_platform_support", default-features = false, features = [
+bevy_platform_support = { git = "https://github.com/bevyengine/bevy.git", default-features = false, features = [
     "std",
 ] }
 # Optional
-bevy_color = { path = "../bevy/crates/bevy_color", default-features = false, optional = true, features = [
+bevy_color = { git = "https://github.com/bevyengine/bevy.git", default-features = false, optional = true, features = [
     "std",
 ] }
-bevy_gizmos = { path = "../bevy/crates/bevy_gizmos", default-features = false, optional = true }
-bevy_render = { path = "../bevy/crates/bevy_render", default-features = false, optional = true }
-bevy_input = { path = "../bevy/crates/bevy_input", default-features = false, optional = true }
-bevy_time = { path = "../bevy/crates/bevy_time", default-features = false, optional = true, features = [
+bevy_gizmos = { git = "https://github.com/bevyengine/bevy.git", default-features = false, optional = true }
+bevy_render = { git = "https://github.com/bevyengine/bevy.git", default-features = false, optional = true }
+bevy_input = { git = "https://github.com/bevyengine/bevy.git", default-features = false, optional = true }
+bevy_time = { git = "https://github.com/bevyengine/bevy.git", default-features = false, optional = true, features = [
     "std",
 ] }
 
 
 [dev-dependencies]
 big_space = { path = "", features = ["debug", "camera"] }
-bevy = { path = "../bevy", default-features = false, features = [
+bevy = { git = "https://github.com/bevyengine/bevy.git", default-features = false, features = [
     "bevy_scene",
     "bevy_asset",
     "bevy_gltf",

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -3,9 +3,9 @@
 use crate::prelude::*;
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
-use bevy_hierarchy::prelude::*;
 use bevy_input::{mouse::MouseMotion, prelude::*};
 use bevy_math::{prelude::*, DQuat, DVec3};
+use bevy_platform_support::collections::HashSet;
 use bevy_reflect::prelude::*;
 use bevy_render::{
     primitives::Aabb,
@@ -13,7 +13,6 @@ use bevy_render::{
 };
 use bevy_time::prelude::*;
 use bevy_transform::{prelude::*, TransformSystem};
-use bevy_utils::HashSet;
 
 /// Adds the `big_space` camera controller
 #[derive(Default)]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -2,7 +2,6 @@
 
 use crate::prelude::*;
 use bevy_ecs::prelude::*;
-use bevy_hierarchy::prelude::*;
 use bevy_transform::prelude::*;
 use smallvec::SmallVec;
 
@@ -205,7 +204,10 @@ impl<'a> SpatialEntityCommands<'a> {
     }
 
     /// Takes a closure which provides a [`ChildBuilder`].
-    pub fn with_children(&mut self, spawn_children: impl FnOnce(&mut ChildBuilder)) -> &mut Self {
+    pub fn with_children(
+        &mut self,
+        spawn_children: impl FnOnce(&mut ChildSpawnerCommands),
+    ) -> &mut Self {
         self.commands
             .entity(self.entity)
             .with_children(|child_builder| spawn_children(child_builder));

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -27,9 +27,9 @@ impl Plugin for FloatingOriginDebugPlugin {
 
 fn setup_gizmos(mut store: ResMut<GizmoConfigStore>) {
     let (config, _) = store.config_mut::<BigSpaceGizmoConfig>();
-    config.line_perspective = false;
-    config.line_joints = GizmoLineJoint::Round(4);
-    config.line_width = 1.0;
+    config.line.perspective = false;
+    config.line.joints = GizmoLineJoint::Round(4);
+    config.line.width = 1.0;
 }
 
 /// Update the rendered debug bounds to only highlight occupied [`GridCell`]s.

--- a/src/floating_origins.rs
+++ b/src/floating_origins.rs
@@ -1,9 +1,8 @@
 //! A floating origin for camera-relative rendering, to maximize precision when converting to f32.
 
 use bevy_ecs::prelude::*;
-use bevy_hierarchy::prelude::*;
+use bevy_platform_support::{collections::HashMap, hash::RandomState};
 use bevy_reflect::prelude::*;
-use bevy_utils::HashMap;
 
 /// Marks the entity to use as the floating origin.
 ///
@@ -51,7 +50,7 @@ impl BigSpace {
     pub(crate) fn validate_floating_origin(
         &self,
         this_entity: Entity,
-        parents: &Query<&Parent>,
+        parents: &Query<&ChildOf>,
     ) -> Option<Entity> {
         let floating_origin = self.floating_origin?;
         let origin_root_entity = parents.iter_ancestors(floating_origin).last()?;
@@ -63,10 +62,10 @@ impl BigSpace {
     /// `BigSpace` hierarchy.
     pub fn find_floating_origin(
         floating_origins: Query<Entity, With<FloatingOrigin>>,
-        parent_query: Query<&Parent>,
+        parent_query: Query<&ChildOf>,
         mut big_spaces: Query<(Entity, &mut BigSpace)>,
     ) {
-        let mut spaces_set = HashMap::new();
+        let mut spaces_set = HashMap::with_hasher(RandomState::default());
         // Reset all floating origin fields, so we know if any are missing.
         for (entity, mut space) in &mut big_spaces {
             space.floating_origin = None;

--- a/src/grid/cell.rs
+++ b/src/grid/cell.rs
@@ -2,11 +2,10 @@
 
 use crate::prelude::*;
 use bevy_ecs::prelude::*;
-use bevy_hierarchy::prelude::*;
 use bevy_math::{DVec3, IVec3};
+use bevy_platform_support::time::Instant;
 use bevy_reflect::prelude::*;
 use bevy_transform::prelude::*;
-use bevy_utils::Instant;
 
 /// Locates an entity in a cell within its parent's [`Grid`]. The [`Transform`] of an entity with
 /// this component is a transformation from the center of this cell.
@@ -84,13 +83,13 @@ impl GridCell {
     pub fn recenter_large_transforms(
         mut stats: ResMut<crate::timing::PropagationStats>,
         grids: Query<&Grid>,
-        mut changed_transform: Query<(&mut Self, &mut Transform, &Parent), Changed<Transform>>,
+        mut changed_transform: Query<(&mut Self, &mut Transform, &ChildOf), Changed<Transform>>,
     ) {
         let start = Instant::now();
         changed_transform
             .par_iter_mut()
             .for_each(|(mut grid_pos, mut transform, parent)| {
-                let Ok(grid) = grids.get(parent.get()) else {
+                let Ok(grid) = grids.get(parent.parent) else {
                     return;
                 };
                 if transform

--- a/src/grid/local_origin.rs
+++ b/src/grid/local_origin.rs
@@ -10,7 +10,6 @@ use bevy_ecs::{
         SystemParam,
     },
 };
-use bevy_hierarchy::prelude::*;
 use bevy_math::{prelude::*, DAffine3, DQuat};
 use bevy_transform::prelude::*;
 
@@ -242,8 +241,8 @@ fn propagate_origin_to_child(
 /// A system param for more easily navigating a hierarchy of [`Grid`]s.
 #[derive(SystemParam)]
 pub struct Grids<'w, 's> {
-    parent: Query<'w, 's, Read<Parent>>,
-    grid_query: Query<'w, 's, (Entity, Read<Grid>, Option<Read<Parent>>)>,
+    parent: Query<'w, 's, Read<ChildOf>>,
+    grid_query: Query<'w, 's, (Entity, Read<Grid>, Option<Read<ChildOf>>)>,
 }
 
 impl Grids<'_, '_> {
@@ -266,7 +265,7 @@ impl Grids<'_, '_> {
     /// Get the ID of the grid that `this` `Entity` is a child of, if it exists.
     #[inline]
     pub fn parent_grid_entity(&self, this: Entity) -> Option<Entity> {
-        match self.parent.get(this).map(|parent| **parent) {
+        match self.parent.get(this).map(|parent| parent.parent) {
             Err(_) => None,
             Ok(parent) => match self.grid_query.contains(parent) {
                 true => Some(parent),
@@ -291,7 +290,7 @@ impl Grids<'_, '_> {
             .iter()
             .filter_map(move |(entity, _, parent)| {
                 parent
-                    .map(|p| p.get())
+                    .map(|p| p.parent)
                     .filter(|parent| *parent == this)
                     .map(|_| entity)
             })
@@ -317,9 +316,9 @@ impl Grids<'_, '_> {
 /// A system param for more easily navigating a hierarchy of grids mutably.
 #[derive(SystemParam)]
 pub struct GridsMut<'w, 's> {
-    parent: Query<'w, 's, Read<Parent>>,
+    parent: Query<'w, 's, Read<ChildOf>>,
     position: Query<'w, 's, (Read<GridCell>, Read<Transform>), With<Grid>>,
-    grid_query: Query<'w, 's, (Entity, Write<Grid>, Option<Read<Parent>>)>,
+    grid_query: Query<'w, 's, (Entity, Write<Grid>, Option<Read<ChildOf>>)>,
 }
 
 impl GridsMut<'_, '_> {
@@ -374,7 +373,7 @@ impl GridsMut<'_, '_> {
     /// Get the ID of the grid that `this` `Entity` is a child of, if it exists.
     #[inline]
     pub fn parent_grid_entity(&self, this: Entity) -> Option<Entity> {
-        match self.parent.get(this).map(|parent| **parent) {
+        match self.parent.get(this).map(|parent| parent.parent) {
             Err(_) => None,
             Ok(parent) => match self.grid_query.contains(parent) {
                 true => Some(parent),
@@ -399,7 +398,7 @@ impl GridsMut<'_, '_> {
             .iter()
             .filter_map(move |(entity, _, parent)| {
                 parent
-                    .map(|p| p.get())
+                    .map(|p| p.parent)
                     .filter(|parent| *parent == this)
                     .map(|_| entity)
             })
@@ -435,9 +434,9 @@ impl LocalFloatingOrigin {
         mut scratch_buffer: Local<Vec<Entity>>,
         cells: Query<(Entity, Ref<GridCell>)>,
         roots: Query<(Entity, &BigSpace)>,
-        parents: Query<&Parent>,
+        parents: Query<&ChildOf>,
     ) {
-        let start = bevy_utils::Instant::now();
+        let start = bevy_platform_support::time::Instant::now();
 
         /// The maximum grid tree depth, defensively prevents infinite looping in case there is a
         /// degenerate hierarchy. It might take a while, but at least it's not forever?

--- a/src/hash/component.rs
+++ b/src/hash/component.rs
@@ -4,10 +4,11 @@ use std::hash::{Hash, Hasher};
 
 use crate::prelude::*;
 use bevy_ecs::prelude::*;
-use bevy_hierarchy::Parent;
 use bevy_math::IVec3;
+use bevy_platform_support::{hash::FixedState, time::Instant};
 use bevy_reflect::Reflect;
-use bevy_utils::{AHasher, Instant, Parallel};
+use bevy_utils::Parallel;
+use std::hash::BuildHasher;
 
 use super::{ChangedGridHashes, GridHashMapFilter};
 
@@ -89,13 +90,13 @@ impl GridHash {
     /// Intentionally left private, so we can ensure the only place these are constructed/mutated is
     /// this module. This allows us to optimize change detection using [`ChangedGridHashes`].
     #[inline]
-    pub(super) fn new(parent: &Parent, cell: &GridCell) -> Self {
-        Self::from_parent(parent.get(), cell)
+    pub(super) fn new(parent: &ChildOf, cell: &GridCell) -> Self {
+        Self::from_parent(parent.parent, cell)
     }
 
     #[inline]
     pub(super) fn from_parent(parent: Entity, cell: &GridCell) -> Self {
-        let hasher = &mut AHasher::default();
+        let hasher = &mut FixedState::with_seed(0).build_hasher();
         hasher.write_u64(parent.to_bits());
         cell.hash(hasher);
 
@@ -160,10 +161,16 @@ impl GridHash {
         mut commands: Commands,
         mut changed_hashes: ResMut<ChangedGridHashes<F>>,
         mut spatial_entities: Query<
-            (Entity, &Parent, &GridCell, &mut GridHash, &mut FastGridHash),
-            (F, Or<(Changed<Parent>, Changed<GridCell>)>),
+            (
+                Entity,
+                &ChildOf,
+                &GridCell,
+                &mut GridHash,
+                &mut FastGridHash,
+            ),
+            (F, Or<(Changed<ChildOf>, Changed<GridCell>)>),
         >,
-        added_entities: Query<(Entity, &Parent, &GridCell), (F, Without<GridHash>)>,
+        added_entities: Query<(Entity, &ChildOf, &GridCell), (F, Without<GridHash>)>,
         mut stats: Option<ResMut<crate::timing::GridHashStats>>,
         mut thread_updated_hashes: Local<Parallel<Vec<Entity>>>,
         mut thread_commands: Local<Parallel<Vec<(Entity, GridHash, FastGridHash)>>>,

--- a/src/hash/map.rs
+++ b/src/hash/map.rs
@@ -5,9 +5,9 @@ use std::{collections::VecDeque, marker::PhantomData, time::Instant};
 use super::GridHashMapFilter;
 use crate::prelude::*;
 use bevy_ecs::{entity::EntityHash, prelude::*};
-use bevy_utils::{
-    hashbrown::{HashMap, HashSet},
-    PassHash,
+use bevy_platform_support::{
+    collections::{HashMap, HashSet},
+    hash::PassHash,
 };
 
 /// An entry in a [`GridHashMap`], accessed with a [`GridHash`].

--- a/src/hash/mod.rs
+++ b/src/hash/mod.rs
@@ -113,7 +113,7 @@ mod tests {
     use std::sync::OnceLock;
 
     use crate::{hash::map::SpatialEntryToEntities, prelude::*};
-    use bevy_utils::hashbrown::HashSet;
+    use bevy_platform_support::collections::HashSet;
 
     #[test]
     fn entity_despawn() {
@@ -269,7 +269,7 @@ mod tests {
         let entities = app.world().resource::<Entities>().clone();
         let parent = app
             .world_mut()
-            .query::<&Parent>()
+            .query::<&ChildOf>()
             .get(app.world(), entities.a)
             .unwrap();
 

--- a/src/hash/partition.rs
+++ b/src/hash/partition.rs
@@ -4,11 +4,12 @@ use std::{hash::Hash, marker::PhantomData, ops::Deref};
 
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
-use bevy_tasks::{ComputeTaskPool, ParallelSliceMut};
-use bevy_utils::{
-    hashbrown::{HashMap, HashSet},
-    Instant, PassHash,
+use bevy_platform_support::{
+    collections::{HashMap, HashSet},
+    hash::PassHash,
+    time::Instant,
 };
+use bevy_tasks::{ComputeTaskPool, ParallelSliceMut};
 
 use super::{GridCell, GridHash, GridHashMap, GridHashMapFilter, GridHashMapSystem};
 
@@ -357,7 +358,7 @@ mod private {
     use super::{GridCell, GridHash};
     use crate::precision::GridPrecision;
     use bevy_ecs::prelude::*;
-    use bevy_utils::{hashbrown::HashSet, PassHash};
+    use bevy_platform_support::{collections::HashSet, hash::PassHash};
 
     /// A group of nearby [`GridCell`](crate::GridCell)s in an island disconnected from all other
     /// [`GridCell`](crate::GridCell)s.
@@ -467,7 +468,9 @@ mod private {
                 if table.len() < Self::MIN_TABLE_SIZE {
                     if let Some(i) = self.smallest_table() {
                         for hash in table.drain() {
-                            self.tables[i].insert_unique_unchecked(hash);
+                            unsafe {
+                                self.tables[i].insert_unique_unchecked(hash);
+                            }
                         }
                     } else {
                         self.tables.push(table);

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -40,7 +40,7 @@ pub enum FloatingOriginSystem {
 impl Plugin for BigSpacePlugin {
     fn build(&self, app: &mut App) {
         // Silence bevy's built-in error spam about GlobalTransforms in the hierarchy
-        app.insert_resource(bevy_hierarchy::ReportHierarchyIssue::<GlobalTransform>::new(false));
+        // app.insert_resource(ReportHierarchyIssue::<GlobalTransform>::new(false));
 
         // Performance timings
         app.add_plugins(crate::timing::TimingStatsPlugin);
@@ -102,7 +102,7 @@ impl Plugin for BigSpacePlugin {
                 PostStartup,
                 (
                     bevy_transform::systems::sync_simple_transforms,
-                    bevy_transform::systems::propagate_transforms,
+                    bevy_transform::systems::propagate_parent_transforms,
                 )
                     .in_set(TransformSystem::TransformPropagate),
             )
@@ -110,7 +110,7 @@ impl Plugin for BigSpacePlugin {
                 PostUpdate,
                 (
                     bevy_transform::systems::sync_simple_transforms,
-                    bevy_transform::systems::propagate_transforms,
+                    bevy_transform::systems::propagate_parent_transforms,
                 )
                     .in_set(TransformSystem::TransformPropagate),
             );


### PR DESCRIPTION
Ports the library to 0.16. Expects bevy to be in the same folder as the repo to build (to match my current build setup), easy to change for anyone deriving off this.

```
     Running unittests src\lib.rs (target\debug\deps\big_space-1d5ff8e69dc7d694.exe)

running 12 tests
test grid::local_origin::tests::origin_transform ... ok
test grid::local_origin::tests::grid_hierarchy_getters ... ok
test grid::local_origin::tests::parent_propagation ... ok
test grid::local_origin::tests::child_propagation ... ok
test hash::tests::neighbors ... ok
test hash::tests::get_hash ... ok
test hash::tests::entity_despawn ... ok
test hash::tests::query_filters ... ok
test grid::propagation::tests::low_precision_in_big_space ... ok
test tests::changing_floating_origin_updates_global_transform ... ok
test tests::child_global_transforms_are_updated_when_floating_origin_changes ... ok
test hash::tests::spatial_map_changed_cell_tracking ... ok

test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.09s```