### PR TITLE
Replace old direct parent field access with parent() method

### DIFF
--- a/src/grid/propagation.rs
+++ b/src/grid/propagation.rs
@@ -291,7 +291,7 @@ impl Grid {
         let Some(children) = children else { return };
         for (child, child_of) in parent_query.iter_many(children) {
             assert_eq!(
-                child_of.parent, entity,
+                child_of.parent(), entity,
                 "Malformed hierarchy. This probably means that your hierarchy has been improperly maintained, or contains a cycle"
             );
             // SAFETY: The caller guarantees that `transform_query` will not be fetched for any

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -144,7 +144,7 @@ pub fn propagate_parent_transforms(
 
             for (child, child_of) in child_query.iter_many(children) {
                 assert_eq!(
-                    child_of.parent, entity,
+                    child_of.parent(), entity,
                     "Malformed hierarchy. This probably means that your hierarchy has been improperly maintained, or contains a cycle"
                 );
                 // SAFETY:
@@ -244,7 +244,7 @@ unsafe fn propagate_recursive(
     let Some(children) = children else { return };
     for (child, child_of) in child_query.iter_many(children) {
         assert_eq!(
-            child_of.parent, entity,
+            child_of.parent(), entity,
             "Malformed hierarchy. This probably means that your hierarchy has been improperly maintained, or contains a cycle"
         );
         // SAFETY: The caller guarantees that `transform_query` will not be fetched for any


### PR DESCRIPTION
Adjustments to `ChildOf` entity after bevyengine/bevy/pull/18672