### PR TITLE
fix: Remove workaround in demo example for bevy_gizmo

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -126,12 +126,10 @@ fn highlight_nearest_sphere(
         return Ok(());
     };
     let transform = objects.get(entity)?;
-    // Ignore rotation due to panicking in gizmos, as of bevy 0.13
-    let (scale, _, translation) = transform.to_scale_rotation_translation();
     gizmos
         .sphere(
-            translation,
-            scale.x * 0.505,
+            transform.translation(),
+            transform.scale().x * 0.505,
             Color::Srgba(palettes::basic::RED),
         )
         .resolution(128);


### PR DESCRIPTION
Just a small tweak to the highlight_nearest_sphere function in examples/demo.rs. I swapped out the old way of pulling out translation and scale from the transform and replaced it with the more straightforward .translation() and .scale() calls. It’s cleaner, easier to read, and allows gizmo to handling rotation.

Tested (ran the demo) on linux under wayland with bevy 0.16.1 and nightly rust