### PR TITLE
update to bevy 0.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "big_space"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "A floating origin plugin for bevy"
 license = "MIT OR Apache-2.0"
@@ -39,38 +39,38 @@ libm = ["bevy_math/libm", "dep:libm"]
 
 [dependencies]
 smallvec = { version = "1.15.0", default-features = false } # Already used by bevy in commands
-bevy_app = { version = "0.18.0", default-features = false, features = [
+bevy_app = { version = "0.19.0", default-features = false, features = [
   "bevy_reflect",
 ] }
-bevy_ecs = { version = "0.18.0", default-features = false }
-bevy_log = { version = "0.18.0", default-features = false }
-bevy_math = { version = "0.18.0", default-features = false }
-bevy_reflect = { version = "0.18.0", default-features = false, features = [
+bevy_ecs = { version = "0.19.0", default-features = false }
+bevy_log = { version = "0.19.0", default-features = false }
+bevy_math = { version = "0.19.0", default-features = false }
+bevy_reflect = { version = "0.19.0", default-features = false, features = [
   "glam",
 ] }
-bevy_tasks = { version = "0.18.0", default-features = false }
-bevy_transform = { version = "0.18.0", default-features = false, features = [
+bevy_tasks = { version = "0.19.0", default-features = false }
+bevy_transform = { version = "0.19.0", default-features = false, features = [
   "bevy-support",
   "bevy_reflect",
 ] }
-bevy_utils = { version = "0.18.0", default-features = false }
-bevy_platform = { version = "0.18.0", default-features = false, features = [
+bevy_utils = { version = "0.19.0", default-features = false }
+bevy_platform = { version = "0.19.0", default-features = false, features = [
   "alloc",
 ] }
 # Optional
-bevy_color = { version = "0.18.0", default-features = false, optional = true }
-bevy_gizmos = { version = "0.18.0", default-features = false, optional = true }
-bevy_camera = { version = "0.18.0", default-features = false, optional = true }
-bevy_input = { version = "0.18.0", default-features = false, optional = true, features = [
+bevy_color = { version = "0.19.0", default-features = false, optional = true }
+bevy_gizmos = { version = "0.19.0", default-features = false, optional = true }
+bevy_camera = { version = "0.19.0", default-features = false, optional = true }
+bevy_input = { version = "0.19.0", default-features = false, optional = true, features = [
   "keyboard",
   "mouse",
 ] }
-bevy_time = { version = "0.18.0", default-features = false }
+bevy_time = { version = "0.19.0", default-features = false }
 libm = { version = "0.2", default-features = false, optional = true }
 async-channel = { version = "2.5", optional = true }
 
 [dev-dependencies]
-bevy = { version = "0.18.0", default-features = false, features = [
+bevy = { version = "0.19.0", default-features = false, features = [
   "bevy_animation",
   "bevy_asset",
   "bevy_color",
@@ -96,7 +96,7 @@ noise = "0.9"
 turborand = "0.10"
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
-bevy = { version = "0.18.0", default-features = false, features = [
+bevy = { version = "0.19.0", default-features = false, features = [
   "multi_threaded",
   "x11",
   "bevy_remote",
@@ -106,7 +106,7 @@ bevy = { version = "0.18.0", default-features = false, features = [
 version = "0.8"
 
 [target.'cfg(target_family = "wasm")'.dev-dependencies]
-bevy = { version = "0.18.0", default-features = false, features = [
+bevy = { version = "0.19.0", default-features = false, features = [
   "web",
   "webgpu",
 ] }

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ https://github.com/user-attachments/assets/9ce5283f-7d48-47dc-beef-9a7626858ed4
 
 | bevy | big_space |
 |------|-----------|
+| 0.19 | 0.13      |
 | 0.18 | 0.12      |
 | 0.17 | 0.11      |
 | 0.16 | 0.10      |

--- a/assets/models/low_poly_spaceship/scene.gltf
+++ b/assets/models/low_poly_spaceship/scene.gltf
@@ -430,7 +430,7 @@
         0.0,
         1.0
       ],
-      "name": "GLTF_SceneRootNode"
+      "name": "GLTF_WorldAssetRootNode"
     },
     {
       "children": [

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -84,11 +84,11 @@ fn ui_setup(mut commands: Commands) {
     commands.spawn((
         Text::default(),
         TextFont {
-            font_size: 18.0,
+            font_size: FontSize::Px(18.0),
             ..default()
         },
         TextColor(Color::WHITE),
-        TextLayout::new_with_justify(Justify::Left),
+        TextLayout::justify(Justify::Left),
         Node {
             position_type: PositionType::Absolute,
             top: Val::Px(10.0),
@@ -101,11 +101,11 @@ fn ui_setup(mut commands: Commands) {
     commands.spawn((
         Text::default(),
         TextFont {
-            font_size: 52.0,
+            font_size: FontSize::Px(52.0),
             ..default()
         },
         TextColor(Color::WHITE),
-        TextLayout::new_with_justify(Justify::Center),
+        TextLayout::justify(Justify::Center),
         Node {
             position_type: PositionType::Absolute,
             bottom: Val::Px(10.0),

--- a/examples/error.rs
+++ b/examples/error.rs
@@ -103,7 +103,7 @@ fn setup_ui(mut commands: Commands) {
     commands.spawn((
         Text::default(),
         TextFont {
-            font_size: 30.0,
+            font_size: FontSize::Px(30.0),
             ..default()
         },
         Node {
@@ -126,13 +126,13 @@ fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
         root.spawn_spatial((distant_grid_cell, FloatingOrigin));
 
         root.spawn_spatial((
-            SceneRoot(asset_server.load("models/low_poly_spaceship/scene.gltf#Scene0")),
+            WorldAssetRoot(asset_server.load("models/low_poly_spaceship/scene.gltf#Scene0")),
             Transform::from_scale(Vec3::splat(0.2)),
             distant_grid_cell,
             Rotator,
         ))
         .with_child((
-            SceneRoot(asset_server.load("models/low_poly_spaceship/scene.gltf#Scene0")),
+            WorldAssetRoot(asset_server.load("models/low_poly_spaceship/scene.gltf#Scene0")),
             Transform::from_xyz(0.0, 0.0, 20.0),
         ));
         // light

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -51,7 +51,7 @@ fn setup_scene(
         // entities (with a GridCell), is also supported. We demonstrate this here by loading in a
         // GLTF scene, which will be added as a child of this entity using low precision Transforms.
         root_grid.spawn_spatial((
-            SceneRoot(asset_server.load("models/low_poly_spaceship/scene.gltf#Scene0")),
+            WorldAssetRoot(asset_server.load("models/low_poly_spaceship/scene.gltf#Scene0")),
             Transform::from_translation(cell_offset - 10.0),
             grid_cell,
         ));

--- a/examples/planets.rs
+++ b/examples/planets.rs
@@ -3,8 +3,8 @@ extern crate alloc;
 
 use alloc::collections::VecDeque;
 
+use bevy::camera::Hdr;
 use bevy::core_pipeline::Skybox;
-use bevy::render::view::Hdr;
 use bevy::window::CursorOptions;
 use bevy::{
     camera::Exposure,
@@ -137,7 +137,7 @@ fn spawn_solar_system(
         DirectionalLight {
             color: Color::WHITE,
             illuminance: 120_000.,
-            shadows_enabled: true,
+            shadow_maps_enabled: true,
             ..default()
         },
         CascadeShadowConfigBuilder {
@@ -261,7 +261,7 @@ fn spawn_solar_system(
                     floating_origin.with_spatial(|ship_scene| {
                         ship_scene.insert((
                             Spaceship,
-                            SceneRoot(
+                            WorldAssetRoot(
                                 asset_server.load("models/low_poly_spaceship/scene.gltf#Scene0"),
                             ),
                             Transform::from_rotation(Quat::from_rotation_y(core::f32::consts::PI)),
@@ -339,13 +339,12 @@ fn configure_skybox_image(
     }
 
     if asset_server.load_state(&cubemap.0).is_loaded() {
-        let image = images.get_mut(&cubemap.0).unwrap();
+        let mut image = images.get_mut(&cubemap.0).unwrap();
+        let layers = image.height() / image.width();
         // NOTE: PNGs do not have any metadata that could indicate they contain a cubemap texture,
         // so they appear as one texture. The following code reconfigures the texture as necessary.
         if image.texture_descriptor.array_layer_count() == 1 {
-            image
-                .reinterpret_stacked_2d_as_array(image.height() / image.width())
-                .unwrap();
+            image.reinterpret_stacked_2d_as_array(layers).unwrap();
             image.texture_view_descriptor =
                 Some(bevy::render::render_resource::TextureViewDescriptor {
                     dimension: Some(bevy::render::render_resource::TextureViewDimension::Cube),
@@ -354,7 +353,7 @@ fn configure_skybox_image(
         }
         let camera = cameras.single().unwrap();
         commands.entity(camera).insert(Skybox {
-            image: cubemap.0.clone(),
+            image: Some(cubemap.0.clone()),
             ..Default::default()
         });
         cubemap.1 = true;

--- a/examples/small_scale.rs
+++ b/examples/small_scale.rs
@@ -79,7 +79,7 @@ fn setup_scene(
 
         // A spaceship
         root_grid.spawn_spatial((
-            SceneRoot(asset_server.load("models/low_poly_spaceship/scene.gltf#Scene0")),
+            WorldAssetRoot(asset_server.load("models/low_poly_spaceship/scene.gltf#Scene0")),
             Transform::from_xyz(0.0, 0.0, 2.5)
                 .with_rotation(Quat::from_rotation_y(core::f32::consts::PI)),
             cell,

--- a/examples/spatial_hash.rs
+++ b/examples/spatial_hash.rs
@@ -4,8 +4,8 @@
 //! rather than one mega grid.
 
 use bevy::{
-    core_pipeline::tonemapping::Tonemapping, post_process::bloom::Bloom, prelude::*,
-    render::view::Hdr, window::CursorOptions,
+    camera::Hdr, core_pipeline::tonemapping::Tonemapping, post_process::bloom::Bloom, prelude::*,
+    window::CursorOptions,
 };
 use bevy_ecs::entity::EntityHasher;
 use bevy_math::DVec3;
@@ -548,8 +548,8 @@ fn setup_ui(mut commands: Commands, asset_server: Res<AssetServer>) {
             parent.spawn((
                 Text::default(),
                 TextFont {
-                    font: asset_server.load("fonts/FiraMono-Regular.ttf"),
-                    font_size: 14.0,
+                    font: asset_server.load("fonts/FiraMono-Regular.ttf").into(),
+                    font_size: FontSize::Px(14.0),
                     ..default()
                 },
             ));

--- a/src/grid/local_origin.rs
+++ b/src/grid/local_origin.rs
@@ -555,7 +555,7 @@ mod tests {
             .add_children(&[child_1, child_2]);
 
         let mut state = SystemState::<GridsMut>::new(app.world_mut());
-        let mut grids = state.get_mut(app.world_mut());
+        let mut grids = state.get_mut(app.world_mut()).expect("could not get grids");
 
         // Children
         let result = grids.child_grids(root).collect::<Vec<_>>();
@@ -613,7 +613,7 @@ mod tests {
         app.world_mut().entity_mut(root).add_child(child);
 
         let mut state = SystemState::<GridsMut>::new(app.world_mut());
-        let mut grids = state.get_mut(app.world_mut());
+        let mut grids = state.get_mut(app.world_mut()).expect("could not get grids");
 
         // The function we are testing
         propagate_origin_to_child(root, &mut grids, child);
@@ -670,7 +670,7 @@ mod tests {
         app.world_mut().entity_mut(root).add_child(child);
 
         let mut state = SystemState::<GridsMut>::new(app.world_mut());
-        let mut grids = state.get_mut(app.world_mut());
+        let mut grids = state.get_mut(app.world_mut()).expect("could not get grids");
 
         // The function we are testing
         propagate_origin_to_parent(child, &mut grids, root);
@@ -734,7 +734,7 @@ mod tests {
         app.world_mut().entity_mut(root).add_child(child);
 
         let mut state = SystemState::<GridsMut>::new(app.world_mut());
-        let mut grids = state.get_mut(app.world_mut());
+        let mut grids = state.get_mut(app.world_mut()).expect("could not get grids");
 
         propagate_origin_to_child(root, &mut grids, child);
 

--- a/src/stationary.rs
+++ b/src/stationary.rs
@@ -146,10 +146,7 @@ fn mark_ancestor_grids(
     parents: &Query<&ChildOf>,
 ) {
     let mut ancestor = start;
-    loop {
-        let Ok(mut dirty) = dirty_ticks.get_mut(ancestor) else {
-            break;
-        };
+    while let Ok(mut dirty) = dirty_ticks.get_mut(ancestor) {
         // bypass_change_detection to avoid spurious Changed<GridDirtyTick> noise
         let d = dirty.bypass_change_detection();
         // Early exit: if already marked this tick, all ancestors were marked too

--- a/src/stationary.rs
+++ b/src/stationary.rs
@@ -372,6 +372,9 @@ mod tests {
 
         let grid_entity = app.world_mut().spawn(BigSpaceRootBundle::default()).id();
 
+        // Pause virtual time so FixedUpdate can't tick early under load.
+        app.world_mut().resource_mut::<Time<Virtual>>().pause();
+
         // Spawn BEFORE any update — this is the first-frame scenario.
         let entity = app
             .world_mut()
@@ -383,23 +386,22 @@ mod tests {
             .set_parent_in_place(grid_entity)
             .id();
 
-        // Frame 0: clock init. is_added() true → no init. FixedUpdate has zero
-        // delta, so it won't tick, but gating resource exists at false regardless.
+        // Frame 0: clock init. is_added() true → no init.
         app.update();
         assert!(
             app.world().get::<StationaryInitialized>(entity).is_none(),
             "Frame 0: should not init (is_added)"
         );
 
-        // Frame 1: near-zero delta, FixedUpdate likely doesn't tick.
-        // is_added() is now false, but FixedUpdateRan is false → gated.
+        // Frame 1: is_added() is now false, but FixedUpdateRan is false → gated.
         app.update();
         assert!(
             app.world().get::<StationaryInitialized>(entity).is_none(),
             "Frame 1: should not init (FixedUpdate hasn't ticked yet)"
         );
 
-        // Sleep so FixedUpdate ticks. Now both conditions are met.
+        // Resume virtual time and sleep so FixedUpdate ticks.
+        app.world_mut().resource_mut::<Time<Virtual>>().unpause();
         thread::sleep(core::time::Duration::from_millis(20));
         app.update();
         assert!(


### PR DESCRIPTION
Updated big space to use bevy 0.19, only required minor fixes for tests and examples. 