### PR TITLE
fix some lingering use of old names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## UNRELEASED
 
+Stationary optimization
+
+## v0.12.0 - 2026-02-08
+
+Bevy 0.18.0, Partition change tracking
+
+## v0.11.0 - 2025-10-20
+
+Bevy 0.17.1
+
 ### Renamed types for consistency
 
 Redundant `Grid` prefix removed.

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -174,7 +174,7 @@ fn spatial_hashing(c: &mut Criterion) {
         .all_entries()
         .find(|(_, entry)| !entry.entities.is_empty())
         .unwrap();
-    group.bench_function("GridHashMap::get", |b| {
+    group.bench_function("CellLookup::get", |b| {
         b.iter(|| {
             black_box(map.get(first.0).unwrap());
         });
@@ -191,7 +191,7 @@ fn spatial_hashing(c: &mut Criterion) {
     });
 
     // let parent = app .world_mut() .query::<&GridHash>() .get(app.world(), ent)
-    //     .unwrap(); let map = app.world().resource::<GridHashMap>(); let entry =
+    //     .unwrap(); let map = app.world().resource::<CellLookup>(); let entry =
     //     map.get(parent).unwrap();
 
     // group.bench_function("Neighbors radius: 4", |b| {

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -190,7 +190,7 @@ fn spatial_hashing(c: &mut Criterion) {
         });
     });
 
-    // let parent = app .world_mut() .query::<&GridHash>() .get(app.world(), ent)
+    // let parent = app .world_mut() .query::<&CellId>() .get(app.world(), ent)
     //     .unwrap(); let map = app.world().resource::<CellLookup>(); let entry =
     //     map.get(parent).unwrap();
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -150,7 +150,7 @@ fn ui_text_system(
     let translation = origin_pos.transform.translation;
 
     let grid_text = format!(
-        "GridCell: {}x, {}y, {}z",
+        "CellCoord: {}x, {}y, {}z",
         origin_pos.cell.x, origin_pos.cell.y, origin_pos.cell.z
     );
 

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -32,7 +32,7 @@ fn setup_scene(
         // Because BIG_DISTANCE is so large, we want to avoid using bevy's f32 transforms alone and
         // experience rounding errors. Instead, we use this helper to convert f64 position into a
         // grid cell and f32 offset.
-        let (grid_cell, cell_offset) = root_grid
+        let (cell_coord, cell_offset) = root_grid
             .grid()
             .translation_to_grid(DVec3::splat(BIG_DISTANCE));
 
@@ -44,16 +44,16 @@ fn setup_scene(
             Mesh3d(meshes.add(Sphere::default())),
             MeshMaterial3d(materials.add(Color::WHITE)),
             Transform::from_translation(cell_offset),
-            grid_cell,
+            cell_coord,
         ));
 
-        // Spawning low-precision entities (without a GridCell) as children of high-precision
-        // entities (with a GridCell), is also supported. We demonstrate this here by loading in a
+        // Spawning low-precision entities (without a CellCoord) as children of high-precision
+        // entities (with a CellCoord), is also supported. We demonstrate this here by loading in a
         // GLTF scene, which will be added as a child of this entity using low precision Transforms.
         root_grid.spawn_spatial((
             SceneRoot(asset_server.load("models/low_poly_spaceship/scene.gltf#Scene0")),
             Transform::from_translation(cell_offset - 10.0),
-            grid_cell,
+            cell_coord,
         ));
 
         // Any spatial entity can be the floating origin. Attaching it to the camera ensures the
@@ -61,7 +61,7 @@ fn setup_scene(
         root_grid.spawn_spatial((
             Camera3d::default(),
             Transform::from_translation(cell_offset + Vec3::new(0.0, 0.0, 10.0)),
-            grid_cell,
+            cell_coord,
             FloatingOrigin,
             BigSpaceCameraController::default(),
         ));

--- a/src/grid/local_origin.rs
+++ b/src/grid/local_origin.rs
@@ -373,7 +373,7 @@ impl GridsMut<'_, '_> {
     pub fn position(&self, grid_entity: Entity) -> (CellCoord, Transform) {
         let (cell, transform) = (CellCoord::default(), Transform::default());
         let (cell, transform) = self.position.get(grid_entity).unwrap_or_else(|_| {
-        assert!(self.parent.get(grid_entity).is_err(), "Grid entity {grid_entity:?} is missing a GridCell and Transform. This is valid only if this is a root grid, but this is not.");
+        assert!(self.parent.get(grid_entity).is_err(), "Grid entity {grid_entity:?} is missing a CellCoord and Transform. This is valid only if this is a root grid, but this is not.");
             (&cell, &transform)
         });
         (*cell, *transform)

--- a/src/grid/mod.rs
+++ b/src/grid/mod.rs
@@ -28,8 +28,8 @@ pub mod propagation;
 /// other using 64-bit float transforms.
 #[derive(Debug, Clone, Reflect, Component)]
 #[reflect(Component)]
-// We do not require the Transform, GlobalTransform, or GridCell, because these are not required in
-// all cases: e.g. BigSpace should not have a Transform or GridCell.
+// We do not require the Transform, GlobalTransform, or CellCoord, because these are not required in
+// all cases: e.g. BigSpace should not have a Transform or CellCoord.
 pub struct Grid {
     /// The high-precision position of the floating origin's current grid cell local to this grid.
     local_floating_origin: LocalFloatingOrigin,

--- a/src/hash/component.rs
+++ b/src/hash/component.rs
@@ -79,7 +79,7 @@ pub struct CellId {
     grid: Entity,
     // The hashed value of the `cell` and `grid` fields. Hash collisions are possible, especially
     // for grids with very large `GridPrecision`s, because a single u64 can only represent the
-    // fraction of possible states compared to an `Entity` (2x u32) and `GridCell` (3x i128)
+    // fraction of possible states compared to an `Entity` (2x u32) and `CellCoord` (3x i128)
     // combined.
     pre_hash: u64,
 }

--- a/src/hash/map.rs
+++ b/src/hash/map.rs
@@ -92,7 +92,7 @@ where
     F: SpatialHashFilter,
 {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("GridHashMap")
+        f.debug_struct("CellLookup")
             .field("map", &self.map)
             .field("reverse_map", &self.reverse_map)
             .finish()
@@ -143,7 +143,7 @@ where
 
     /// Iterate over this cell and its non-empty adjacent neighbors.
     ///
-    /// `GridHashEntry`s cache information about their neighbors as the spatial map is updated,
+    /// `CellLookupEntry`s cache information about their neighbors as the spatial map is updated,
     /// making it faster to look up neighboring entries when compared to computing all neighbor
     /// hashes and checking if they exist.
     ///
@@ -474,7 +474,7 @@ where
                 let entry = self
                     .spatial_map
                     .get(neighbor_hash)
-                    .expect("Neighbor hashes in GridHashEntry are guaranteed to exist.");
+                    .expect("Neighbor hashes in CellLookupEntry are guaranteed to exist.");
                 (neighbor_hash, entry)
             })
         {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@
 //! over the others are:
 //! - Absolute high-precision positions in space that do not change when the camera moves. The only
 //!   component that is affected by precision loss is the `GlobalTransform` used for rendering. The
-//!   `GridCell` and `Transform` only change when an entity moves. This is especially useful for
+//!   `CellCoord` and `Transform` only change when an entity moves. This is especially useful for
 //!   multiplayer - the server needs a source of truth for position that doesn't drift over time.
 //! - Virtually limitless volume and scale; you can work at the scale of subatomic particles, across
 //!   the width of the observable universe. Double precision is downright suffocating in comparison.
@@ -81,15 +81,15 @@
 //!   from the origin of the current grid cell.
 //! - High precision coordinates are invisible if you don't need them. You can move objects using
 //!   their `Transform` alone, which results in decent ecosystem compatibility.
-//! - High precision coordinates optional. If you don't add the `GridCell` component to an entity,
+//! - High precision coordinates optional. If you don't add the `CellCoord` component to an entity,
 //!   it behaves like a normal single precision transform, with the same performance cost, yet it
 //!   can exist in the high-precision hierarchy. This allows you to load in GLTFs or other
 //!   low-precision entity hierarchies with no added effort or cost.
 //!
 //! While using the [`BigSpaceDefaultPlugins`], the position of entities is now defined with the [`Grid`],
 //! [`CellCoord`], and [`Transform`] components. The `Grid` is a large integer grid of cells;
-//! entities are located within this grid as children using the `GridCell` component. Finally, the
-//! `Transform` is used to position the entity relative to the center of its `GridCell`. If an
+//! entities are located within this grid as children using the `CellCoord` component. Finally, the
+//! `Transform` is used to position the entity relative to the center of its `CellCoord`. If an
 //! entity moves into a neighboring cell, its transform will be automatically recomputed relative to
 //! the center of that new cell. This prevents `Transforms` from ever becoming larger than a single
 //! grid cell and thus prevents floating point precision artifacts.
@@ -133,7 +133,7 @@
 //! only affects the `GlobalTransform` and not the `Transform`, this also means that entities will
 //! never permanently lose precision just because they were far from the origin at some point. The
 //! lossy calculation only occurs when computing the `GlobalTransform` of entities, the
-//! high-precision `GridCell` and `Transform` are not affected.
+//! high-precision `CellCoord` and `Transform` are not affected.
 //!
 //! # Usage
 //!


### PR DESCRIPTION
I noticed a few places where the old names hadn't been updated. This PR should correct all instances to use the new names. This is based on the name changes documented in the changelog, so it won't cover others that didn't get documented.

Also brought the changelog up to date, based on a cursory skim of the git history. 